### PR TITLE
Avoid using pointers to temporary copies of desired extensions.

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -384,7 +384,7 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     KP_LOG_DEBUG("Kompute Manager available extensions {}",
                  uniqueExtensionNames);
     std::vector<const char*> validExtensions;
-    for (std::string ext : desiredExtensions) {
+    for (const std::string& ext : desiredExtensions) {
         if (uniqueExtensionNames.count(ext) != 0) {
             validExtensions.push_back(ext.c_str());
         }


### PR DESCRIPTION
validExtensions now references data that remains constant for its entire life-time.