### PR TITLE
Remove nonexisting "single_include" from INSTALL_INTERFACE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,8 +54,6 @@ target_include_directories(
     kompute PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
-    $<INSTALL_INTERFACE:include>
-    $<INSTALL_INTERFACE:single_include>
 )
 
 if(NOT KOMPUTE_OPT_ANDROID_BUILD)
@@ -150,6 +148,8 @@ if(KOMPUTE_OPT_INSTALL)
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         INCLUDES DESTINATION include)
+
+    target_include_directories(kompute PUBLIC $<INSTALL_INTERFACE:include>)
 
     install(DIRECTORY include/ DESTINATION include)
 


### PR DESCRIPTION
CMake considers it an error that the target kompute::kompute references the "single_include" folder which is actually installed to "include".

CMakeLists.txt:-1: error: Imported target "kompute::kompute" includes non-existent path "D:/Downloads/kompute-0.8.0/build/install/single_include" in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include: * The path was deleted, renamed, or moved to another location. * An install or uninstall procedure did not complete successfully. * The installation package was faulty and references files it does not provide.