### PR TITLE
Fix TestDestroy.TestDestroyTensorSingle

### DIFF
--- a/test/TestDestroy.cpp
+++ b/test/TestDestroy.cpp
@@ -27,17 +27,27 @@ TEST(TestDestroy, TestDestroyTensorSingle)
         {
             kp::Manager mgr;
 
-            tensorA = mgr.tensor({ 0, 0, 0 });
+            const std::vector<float> initialValues = {0.0f, 0.0f, 0.0f};
+
+            tensorA = mgr.tensor(initialValues);
 
             std::shared_ptr<kp::Algorithm> algo =
-              mgr.algorithm({ tensorA }, spirv);
+              mgr.algorithm({tensorA}, spirv);
+
+            // Sync values to and from device
+            mgr.sequence()
+            ->eval<kp::OpTensorSyncDevice>(algo->getTensors())
+            ->eval<kp::OpTensorSyncLocal>(algo->getTensors());
+
+            EXPECT_EQ(tensorA->vector(), initialValues);
 
             mgr.sequence()
               ->record<kp::OpAlgoDispatch>(algo)
               ->eval()
               ->eval<kp::OpTensorSyncLocal>(algo->getTensors());
 
-            EXPECT_EQ(tensorA->vector(), std::vector<float>({ 1, 1, 1 }));
+            const std::vector<float> expectedFinalValues = {1.0f, 1.0f, 1.0f};
+            EXPECT_EQ(tensorA->vector(), expectedFinalValues);
 
             tensorA->destroy();
             EXPECT_FALSE(tensorA->isInit());

--- a/test/TestDestroy.cpp
+++ b/test/TestDestroy.cpp
@@ -36,8 +36,7 @@ TEST(TestDestroy, TestDestroyTensorSingle)
 
             // Sync values to and from device
             mgr.sequence()
-            ->eval<kp::OpTensorSyncDevice>(algo->getTensors())
-            ->eval<kp::OpTensorSyncLocal>(algo->getTensors());
+            ->eval<kp::OpTensorSyncDevice>(algo->getTensors());
 
             EXPECT_EQ(tensorA->vector(), initialValues);
 


### PR DESCRIPTION
This PR fixes this test by first syncing the tensor data to the device. When I run the test suite multiple times on my real hardware, the memory on the device was never initialized, so the test would fail on the first run, then succeed, then fail thereafter.