### PR TITLE
Removed '#pragma once' from cpp files

### DIFF
--- a/src/OpAlgoDispatch.cpp
+++ b/src/OpAlgoDispatch.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#pragma once
 
 #include "kompute/operations/OpAlgoDispatch.hpp"
 

--- a/src/OpMemoryBarrier.cpp
+++ b/src/OpMemoryBarrier.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#pragma once
 
 #include "kompute/operations/OpMemoryBarrier.hpp"
 


### PR DESCRIPTION
This PR removes `#pragma once` since `.cpp` are generally not supposed to be included anywhere.

Partially resolves #278