### PR TITLE
Fixed Vulkan deprecation warning

### DIFF
--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -305,7 +305,7 @@ Algorithm::createPipeline()
     this->mFreePipeline = true;
 #else
     vk::Pipeline pipeline =
-      this->mDevice->createComputePipeline(*this->mPipelineCache, pipelineInfo);
+      this->mDevice->createComputePipeline(*this->mPipelineCache, pipelineInfo).value;
     this->mPipeline = std::make_shared<vk::Pipeline>(pipeline);
     this->mFreePipeline = true;
 #endif


### PR DESCRIPTION
The value of `ResultValue<T>` should be accessed explicitly. Implicit access is deprecated.
Fixes the second half of: https://github.com/KomputeProject/kompute/issues/278