### PR TITLE
Enum class fix for fmt 8.x

### DIFF
--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -598,6 +598,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
+#include <string>
 
 #include <vulkan/vulkan.hpp>
 
@@ -2368,3 +2370,37 @@ class Manager
 };
 
 } // End namespace kp
+
+/**
+ * fmt fromater for kp::Tensor::TensorDataTypes.
+ */
+template <> struct fmt::formatter<kp::Tensor::TensorDataTypes>: formatter<std::string> {
+  template <typename FormatContext>
+  auto format(kp::Tensor::TensorDataTypes dt, FormatContext& ctx) {
+    std::string name = "unknown";
+    switch (dt) {
+      case kp::Tensor::TensorDataTypes::eBool: name = "eBool"; break;
+      case kp::Tensor::TensorDataTypes::eDouble: name = "eDouble"; break;
+      case kp::Tensor::TensorDataTypes::eFloat: name = "eFloat"; break;
+      case kp::Tensor::TensorDataTypes::eInt: name = "eInt"; break;
+      case kp::Tensor::TensorDataTypes::eUnsignedInt: name = "eUnsignedInt"; break;
+    }
+    return formatter<std::string>::format(name, ctx);
+  }
+};
+
+/**
+ * fmt fromater for kp::Tensor::TensorTypes.
+ */
+template <> struct fmt::formatter<kp::Tensor::TensorTypes>: formatter<std::string> {
+  template <typename FormatContext>
+  auto format(kp::Tensor::TensorTypes dt, FormatContext& ctx) {
+    std::string name = "unknown";
+    switch (dt) {
+      case kp::Tensor::TensorTypes::eDevice: name = "eDevice"; break;
+      case kp::Tensor::TensorTypes::eHost: name = "eHost"; break;
+      case kp::Tensor::TensorTypes::eStorage: name = "eStorage"; break;
+    }
+    return formatter<std::string>::format(name, ctx);
+  }
+};

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -2,6 +2,8 @@
 #pragma once
 
 #include "kompute/Core.hpp"
+#include <fmt/format.h>
+#include <string>
 
 namespace kp {
 
@@ -339,3 +341,37 @@ class TensorT : public Tensor
 };
 
 } // End namespace kp
+
+/**
+ * fmt fromater for kp::Tensor::TensorDataTypes.
+ */
+template <> struct fmt::formatter<kp::Tensor::TensorDataTypes>: formatter<std::string> {
+  template <typename FormatContext>
+  auto format(kp::Tensor::TensorDataTypes dt, FormatContext& ctx) {
+    std::string name = "unknown";
+    switch (dt) {
+      case kp::Tensor::TensorDataTypes::eBool: name = "eBool"; break;
+      case kp::Tensor::TensorDataTypes::eDouble: name = "eDouble"; break;
+      case kp::Tensor::TensorDataTypes::eFloat: name = "eFloat"; break;
+      case kp::Tensor::TensorDataTypes::eInt: name = "eInt"; break;
+      case kp::Tensor::TensorDataTypes::eUnsignedInt: name = "eUnsignedInt"; break;
+    }
+    return formatter<std::string>::format(name, ctx);
+  }
+};
+
+/**
+ * fmt fromater for kp::Tensor::TensorTypes.
+ */
+template <> struct fmt::formatter<kp::Tensor::TensorTypes>: formatter<std::string> {
+  template <typename FormatContext>
+  auto format(kp::Tensor::TensorTypes dt, FormatContext& ctx) {
+    std::string name = "unknown";
+    switch (dt) {
+      case kp::Tensor::TensorTypes::eDevice: name = "eDevice"; break;
+      case kp::Tensor::TensorTypes::eHost: name = "eHost"; break;
+      case kp::Tensor::TensorTypes::eStorage: name = "eStorage"; break;
+    }
+    return formatter<std::string>::format(name, ctx);
+  }
+};


### PR DESCRIPTION
Since fmt 8.0.0 enum classes are not being implicitly converted to int any more.
Refference: https://github.com/fmtlib/fmt/issues/1841

Since I have to use fmt 8.0 and therefore can not use the one provided by Kompute, I defined a format extension for `kp::Tensor::TensorDataTypes` and `kp::Tensor::TensorTypes`.

I'm not too sure if they are required in both classes `Tensor.hpp` and `Kompute.hpp`.
Also let me know if the formatting of the code is fine that way, since I was not able to find any guidelines (e.g. a `.clang-format` file).