### PR TITLE
Fixed compiler warnings

### DIFF
--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -2069,15 +2069,15 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      *
      * @return Boolean stating if recording ongoing.
      */
-    bool isRecording();
+    [[nodiscard]] bool isRecording() const;
 
     /**
      * Returns true if the sequence has been initialised, and it's based on the
-     * GPU resources being refrenced.
+     * GPU resources being referenced.
      *
      * @return Boolean stating if is initialized
      */
-    bool isInit();
+    [[nodiscard]] bool isInit() const;
 
     /**
      * Clears command buffer and triggers re-record of all the current
@@ -2092,7 +2092,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      *
      * @return Boolean stating if currently running.
      */
-    bool isRunning();
+    [[nodiscard]] bool isRunning() const;
 
     /**
      * Destroys and frees the GPU resources which include the buffer and memory

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -31,7 +31,8 @@ debugMessageCallback(VkDebugReportFlagsEXT flags,
 
 Manager::Manager()
   : Manager(0)
-{}
+{
+}
 
 Manager::Manager(uint32_t physicalDeviceIndex,
                  const std::vector<uint32_t>& familyQueueIndices,
@@ -282,10 +283,6 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     if (this->mInstance == nullptr) {
         throw std::runtime_error("Kompute Manager instance is null");
     }
-    if (physicalDeviceIndex < 0) {
-        throw std::runtime_error(
-          "Kompute Manager physical device index not provided");
-    }
 
     this->mFreeDevice = true;
 
@@ -321,12 +318,13 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
                 physicalDeviceIndex,
                 physicalDeviceProperties.deviceName);
 
-    if (!familyQueueIndices.size()) {
+    if (familyQueueIndices.empty()) {
         // Find compute queue
         std::vector<vk::QueueFamilyProperties> allQueueFamilyProperties =
           physicalDevice.getQueueFamilyProperties();
 
-        uint32_t computeQueueFamilyIndex = -1;
+        uint32_t computeQueueFamilyIndex = 0;
+        bool computeQueueSupported = false;
         for (uint32_t i = 0; i < allQueueFamilyProperties.size(); i++) {
             vk::QueueFamilyProperties queueFamilyProperties =
               allQueueFamilyProperties[i];
@@ -334,11 +332,12 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
             if (queueFamilyProperties.queueFlags &
                 vk::QueueFlagBits::eCompute) {
                 computeQueueFamilyIndex = i;
+                computeQueueSupported = true;
                 break;
             }
         }
 
-        if (computeQueueFamilyIndex < 0) {
+        if (!computeQueueSupported) {
             throw std::runtime_error("Compute queue is not supported");
         }
 

--- a/src/OpAlgoDispatch.cpp
+++ b/src/OpAlgoDispatch.cpp
@@ -43,13 +43,13 @@ OpAlgoDispatch::record(const vk::CommandBuffer& commandBuffer)
 }
 
 void
-OpAlgoDispatch::preEval(const vk::CommandBuffer& commandBuffer)
+OpAlgoDispatch::preEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpAlgoDispatch preEval called");
 }
 
 void
-OpAlgoDispatch::postEval(const vk::CommandBuffer& commandBuffer)
+OpAlgoDispatch::postEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpAlgoDispatch postSubmit called");
 }

--- a/src/OpMemoryBarrier.cpp
+++ b/src/OpMemoryBarrier.cpp
@@ -11,12 +11,12 @@ OpMemoryBarrier::OpMemoryBarrier(
   const vk::PipelineStageFlagBits& srcStageMask,
   const vk::PipelineStageFlagBits& dstStageMask,
   bool barrierOnPrimary)
-  : mTensors(tensors)
-  , mSrcAccessMask(srcAccessMask)
+  : mSrcAccessMask(srcAccessMask)
   , mDstAccessMask(dstAccessMask)
   , mSrcStageMask(srcStageMask)
   , mDstStageMask(dstStageMask)
   , mBarrierOnPrimary(barrierOnPrimary)
+  , mTensors(tensors)
 {
     KP_LOG_DEBUG("Kompute OpMemoryBarrier constructor");
 }
@@ -52,13 +52,13 @@ OpMemoryBarrier::record(const vk::CommandBuffer& commandBuffer)
 }
 
 void
-OpMemoryBarrier::preEval(const vk::CommandBuffer& commandBuffer)
+OpMemoryBarrier::preEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpMemoryBarrier preEval called");
 }
 
 void
-OpMemoryBarrier::postEval(const vk::CommandBuffer& commandBuffer)
+OpMemoryBarrier::postEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpMemoryBarrier postSubmit called");
 }

--- a/src/OpTensorCopy.cpp
+++ b/src/OpTensorCopy.cpp
@@ -50,13 +50,13 @@ OpTensorCopy::record(const vk::CommandBuffer& commandBuffer)
 }
 
 void
-OpTensorCopy::preEval(const vk::CommandBuffer& commandBuffer)
+OpTensorCopy::preEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorCopy preEval called");
 }
 
 void
-OpTensorCopy::postEval(const vk::CommandBuffer& commandBuffer)
+OpTensorCopy::postEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorCopy postEval called");
 

--- a/src/OpTensorSyncDevice.cpp
+++ b/src/OpTensorSyncDevice.cpp
@@ -37,13 +37,13 @@ OpTensorSyncDevice::record(const vk::CommandBuffer& commandBuffer)
 }
 
 void
-OpTensorSyncDevice::preEval(const vk::CommandBuffer& commandBuffer)
+OpTensorSyncDevice::preEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorSyncDevice preEval called");
 }
 
 void
-OpTensorSyncDevice::postEval(const vk::CommandBuffer& commandBuffer)
+OpTensorSyncDevice::postEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorSyncDevice postEval called");
 }

--- a/src/OpTensorSyncLocal.cpp
+++ b/src/OpTensorSyncLocal.cpp
@@ -52,13 +52,13 @@ OpTensorSyncLocal::record(const vk::CommandBuffer& commandBuffer)
 }
 
 void
-OpTensorSyncLocal::preEval(const vk::CommandBuffer& commandBuffer)
+OpTensorSyncLocal::preEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorSyncLocal preEval called");
 }
 
 void
-OpTensorSyncLocal::postEval(const vk::CommandBuffer& commandBuffer)
+OpTensorSyncLocal::postEval(const vk::CommandBuffer& /*commandBuffer*/)
 {
     KP_LOG_DEBUG("Kompute OpTensorSyncLocal postEval called");
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -174,19 +174,19 @@ Sequence::evalAwait(uint64_t waitFor)
 }
 
 bool
-Sequence::isRunning()
+Sequence::isRunning() const
 {
     return this->mIsRunning;
 }
 
 bool
-Sequence::isRecording()
+Sequence::isRecording() const
 {
     return this->mRecording;
 }
 
 bool
-Sequence::isInit()
+Sequence::isInit() const
 {
     return this->mDevice && this->mCommandPool && this->mCommandBuffer &&
            this->mComputeQueue;
@@ -303,9 +303,6 @@ Sequence::createCommandPool()
 
     if (!this->mDevice) {
         throw std::runtime_error("Kompute Sequence device is null");
-    }
-    if (this->mQueueIndex < 0) {
-        throw std::runtime_error("Kompute Sequence queue index not provided");
     }
 
     this->mFreeCommandPool = true;

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -210,7 +210,7 @@ void
 Tensor::recordCopyBuffer(const vk::CommandBuffer& commandBuffer,
                          std::shared_ptr<vk::Buffer> bufferFrom,
                          std::shared_ptr<vk::Buffer> bufferTo,
-                         vk::DeviceSize bufferSize,
+                         vk::DeviceSize /*bufferSize*/,
                          vk::BufferCopy copyRegion)
 {
 
@@ -439,16 +439,18 @@ Tensor::allocateBindMemory(std::shared_ptr<vk::Buffer> buffer,
       this->mDevice->getBufferMemoryRequirements(*buffer);
 
     uint32_t memoryTypeIndex = -1;
+    bool memoryTypeIndexFound = false;
     for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; i++) {
         if (memoryRequirements.memoryTypeBits & (1 << i)) {
             if (((memoryProperties.memoryTypes[i]).propertyFlags &
                  memoryPropertyFlags) == memoryPropertyFlags) {
                 memoryTypeIndex = i;
+                memoryTypeIndexFound = true;
                 break;
             }
         }
     }
-    if (memoryTypeIndex < 0) {
+    if (!memoryTypeIndexFound) {
         throw std::runtime_error(
           "Memory type index for buffer creation not found");
     }

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -235,15 +235,15 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      *
      * @return Boolean stating if recording ongoing.
      */
-    bool isRecording();
+    [[nodiscard]] bool isRecording() const;
 
     /**
      * Returns true if the sequence has been initialised, and it's based on the
-     * GPU resources being refrenced.
+     * GPU resources being referenced.
      *
      * @return Boolean stating if is initialized
      */
-    bool isInit();
+    [[nodiscard]] bool isInit() const;
 
     /**
      * Clears command buffer and triggers re-record of all the current
@@ -258,7 +258,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      *
      * @return Boolean stating if currently running.
      */
-    bool isRunning();
+    [[nodiscard]] bool isRunning() const;
 
     /**
      * Destroys and frees the GPU resources which include the buffer and memory
@@ -281,7 +281,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
 
     // -------------- ALWAYS OWNED RESOURCES
     vk::Fence mFence;
-    std::vector<std::shared_ptr<OpBase>> mOperations;
+    std::vector<std::shared_ptr<OpBase>> mOperations{};
     std::shared_ptr<vk::QueryPool> timestampQueryPool = nullptr;
 
     // State


### PR DESCRIPTION
In preparation for the build system rewrite where ```-Wall -Wextra -Wpedantic -Werror``` will be set by default, this PR fixes all warnings reported.

I removed
```c++
if (this->mQueueIndex < 0) {
    throw std::runtime_error("Kompute Sequence queue index not provided");
}
```
without any replacement since `mQueueIndex` will be always set in the constructor anyway.

Fixes: https://github.com/KomputeProject/kompute/issues/278