### PR TITLE
Added an option to get the current vk instance

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -450,4 +450,10 @@ Manager::listDevices() const
     return this->mInstance->enumeratePhysicalDevices();
 }
 
+std::shared_ptr<vk::Instance>
+Manager::getVkInstance() const
+{
+    return this->mInstance;
+}
+
 }

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -214,6 +214,14 @@ class Manager
      **/
     std::vector<vk::PhysicalDevice> listDevices() const;
 
+    /**
+     * The current Vulkan instance.
+     *
+     * @return a shared pointer to the current Vulkan instance held by this
+     *object
+     **/
+    std::shared_ptr<vk::Instance> getVkInstance() const;
+
   private:
     // -------------- OPTIONALLY OWNED RESOURCES
     std::shared_ptr<vk::Instance> mInstance = nullptr;


### PR DESCRIPTION
In order to debug compute shaders using [RenderDoc](https://renderdoc.org/) and its [in application API](https://renderdoc.org/docs/in_application_api.html), one needs access to the `vk::Instance` object held by the `kp::Manager`. This PR introduces a new getter for retrieving the `std::shared_ptr<vk::Instance>` via the `Manager::getVkInstance()`call.