### PR TITLE
Fixes two mistakes in comments and removes one unused vk::MappedMemoryRange

### DIFF
--- a/examples/godot_examples/gdnative_shared/README.md
+++ b/examples/godot_examples/gdnative_shared/README.md
@@ -12,16 +12,15 @@ git clone --branch 3.2 https://github.com/godotengine/godot-cpp
 cd godot-cpp
 ```
 
-Then we can get all the subomdules
+Then we can get all the submodules
 
 ```
 git submodule sync
 ```
 
-and we build the bindings
+And we build the bindings
 
 ```
 scons -j16 platform=linuxbsd target=debug
 
 ```
-

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -132,7 +132,6 @@ Tensor::mapRawData()
     this->mRawData = this->mDevice->mapMemory(
       *hostVisibleMemory, 0, bufferSize, vk::MemoryMapFlags());
 
-    vk::MappedMemoryRange mappedMemoryRange(*hostVisibleMemory, 0, bufferSize);
 }
 
 void
@@ -241,7 +240,7 @@ Tensor::recordStagingBufferMemoryBarrier(const vk::CommandBuffer& commandBuffer,
                                          vk::PipelineStageFlagBits srcStageMask,
                                          vk::PipelineStageFlagBits dstStageMask)
 {
-    KP_LOG_DEBUG("Kompute Tensor recording PRIMARY buffer memory barrier");
+    KP_LOG_DEBUG("Kompute Tensor recording STAGING buffer memory barrier");
 
     this->recordBufferMemoryBarrier(commandBuffer,
                                     *this->mStagingBuffer,

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -217,16 +217,12 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     /**
      * Begins recording commands for commands to be submitted into the command
      * buffer.
-     *
-     * @return Boolean stating whether execution was successful.
      */
     void begin();
 
     /**
      * Ends the recording and stops recording commands when the record command
      * is sent.
-     *
-     * @return Boolean stating whether execution was successful.
      */
     void end();
 


### PR DESCRIPTION
I was reading through implementation of Kompute and noticed couple small mistakes that should not effect any functionality.

This minor PR fixes them.