### PR TITLE
Updated the fetch_content git repo and commit hash

### DIFF
--- a/docs/overview/shaders-to-headers.rst
+++ b/docs/overview/shaders-to-headers.rst
@@ -84,7 +84,7 @@ If you are using CMake as build system you can use CMake to directly convert you
     # Consume Kompute via CMake fetch_content
     include(FetchContent)
     FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/KomputeProject/kompute.git
-                                 GIT_TAG f4d72e2aa7b23ffe05d5ea3191bf72ad00def0ec) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
+                                 GIT_TAG 1344ece4ac278f9b3be3b4555ffaace7a032b91f) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
     FetchContent_MakeAvailable(kompute)
     include_directories(${kompute_SOURCE_DIR}/src/include)
 

--- a/examples/android/android-simple/app/src/main/cpp/CMakeLists.txt
+++ b/examples/android/android-simple/app/src/main/cpp/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.20)
 set(CMAKE_CXX_STANDARD 17)
 
 include(FetchContent)
-FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/COM8/kompute.git
-                             GIT_TAG 675f6dc771cea044ead99a5467a9b817c2d8feb6) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
+FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/KomputeProject/kompute.git
+                             GIT_TAG 1344ece4ac278f9b3be3b4555ffaace7a032b91f) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
 set(KOMPUTE_OPT_ANDROID_BUILD ON)
 set(KOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS ON)
 FetchContent_MakeAvailable(kompute)

--- a/examples/array_multiplication/CMakeLists.txt
+++ b/examples/array_multiplication/CMakeLists.txt
@@ -25,8 +25,8 @@ if(WIN32) # Install dlls in the same directory as the executable on Windows
 endif()
 
 include(FetchContent)
-FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/COM8/kompute.git
-    GIT_TAG f4d72e2aa7b23ffe05d5ea3191bf72ad00def0ec) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
+FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/KomputeProject/kompute.git
+    GIT_TAG 1344ece4ac278f9b3be3b4555ffaace7a032b91f) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
 FetchContent_MakeAvailable(kompute)
 include_directories(${kompute_SOURCE_DIR}/src/include)
 

--- a/examples/logistic_regression/CMakeLists.txt
+++ b/examples/logistic_regression/CMakeLists.txt
@@ -25,8 +25,8 @@ if(WIN32) # Install dlls in the same directory as the executable on Windows
 endif()
 
 include(FetchContent)
-FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/COM8/kompute.git
-    GIT_TAG f4d72e2aa7b23ffe05d5ea3191bf72ad00def0ec) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
+FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/KomputeProject/kompute.git
+    GIT_TAG 1344ece4ac278f9b3be3b4555ffaace7a032b91f) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
 FetchContent_MakeAvailable(kompute)
 include_directories(${kompute_SOURCE_DIR}/src/include)
 


### PR DESCRIPTION
Updates the CMake `fetch_content` repository and git commit to a official Kompute repo.
As mentioned in #287 this had to be done as a successor of #287 once we knew the actual commit hash after merging.