### PR TITLE
Upgrading to Vulkan 1.3

### DIFF
--- a/.github/workflows/cpp_tests.yml
+++ b/.github/workflows/cpp_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cpp-tests-debug-with-debug-layers:
     runs-on: ubuntu-latest
-    container: axsauze/kompute-builder:0.3
+    container: axsauze/kompute-builder:0.4
     steps:
     - name: Install vulkaninfo
       run: apt update -y && apt install -y vulkan-tools
@@ -28,6 +28,7 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=OFF -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
+        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -35,10 +36,8 @@ jobs:
   
   cpp-tests-release-with-debug-layers:
     runs-on: ubuntu-latest
-    container: axsauze/kompute-builder:0.3
+    container: axsauze/kompute-builder:0.4
     steps:
-    - name: Install vulkaninfo
-      run: apt update -y && apt install -y vulkan-tools
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -54,6 +53,7 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=OFF -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
+        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -61,10 +61,8 @@ jobs:
 
   cpp-tests-debug-without-debug-layers:
     runs-on: ubuntu-latest
-    container: axsauze/kompute-builder:0.3
+    container: axsauze/kompute-builder:0.4
     steps:
-    - name: Install vulkaninfo
-      run: apt update -y && apt install -y vulkan-tools
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -80,6 +78,7 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=ON -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
+        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -87,10 +86,8 @@ jobs:
   
   cpp-tests-release-without-debug-layers:
     runs-on: ubuntu-latest
-    container: axsauze/kompute-builder:0.3
+    container: axsauze/kompute-builder:0.4
     steps:
-    - name: Install vulkaninfo
-      run: apt update -y && apt install -y vulkan-tools
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -106,6 +103,7 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=ON -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
+        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"

--- a/.github/workflows/cpp_tests.yml
+++ b/.github/workflows/cpp_tests.yml
@@ -28,7 +28,6 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=OFF -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
-        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -53,7 +52,6 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=OFF -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
-        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -78,7 +76,6 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=ON -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
-        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"
@@ -103,7 +100,6 @@ jobs:
         run-test: false
         ctest-options: -V
         configure-options: -DKOMPUTE_OPT_BUILD_TESTS=ON -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=ON -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON
-        build-options: --parallel
     - name: Run tests
       env:
         VK_ICD_FILENAMES: "/swiftshader/vk_swiftshader_icd.json"

--- a/.github/workflows/cpp_tests.yml
+++ b/.github/workflows/cpp_tests.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         submodules: false
     - name: "[Release g++] Build & Test"
-      uses: ashutoshvarma/action-cmake-build@master
+      uses: KomputeProject/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
         source-dir: ${{github.workspace}}
@@ -43,7 +43,7 @@ jobs:
       with:
         submodules: false
     - name: "[Release g++] Build & Test"
-      uses: ashutoshvarma/action-cmake-build@master
+      uses: KomputeProject/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
         source-dir: ${{github.workspace}}
@@ -68,7 +68,7 @@ jobs:
       with:
         submodules: false
     - name: "[Release g++] Build & Test"
-      uses: ashutoshvarma/action-cmake-build@master
+      uses: KomputeProject/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
         source-dir: ${{github.workspace}}
@@ -93,7 +93,7 @@ jobs:
       with:
         submodules: false
     - name: "[Release g++] Build & Test"
-      uses: ashutoshvarma/action-cmake-build@master
+      uses: KomputeProject/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
         source-dir: ${{github.workspace}}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,14 +9,12 @@ on:
 jobs:
   python-tests:
     runs-on: ubuntu-latest
-    container: axsauze/kompute-builder:0.3
+    container: axsauze/kompute-builder:0.4
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         submodules: false
-    - name: Install vulkaninfo
-      run: apt update -y && apt install -y vulkan-tools
     - name: Install Python Requirements
       run: pip3 install --user -r python/test/requirements-dev.txt
     - name: Python Build

--- a/docker-builders/KomputeBuilder.Dockerfile
+++ b/docker-builders/KomputeBuilder.Dockerfile
@@ -1,4 +1,22 @@
-FROM ubuntu:20.04
+
+ARG VULKAN_SDK_VERSION
+ARG SWIFTSHADER_VERSION
+
+# Using FROM reference as COPY command doesn't support args
+FROM axsauze/vulkan-sdk:${VULKAN_SDK_VERSION} as vulkansdk-image
+FROM axsauze/swiftshader:${SWIFTSHADER_VERSION} as swiftshader-image
+
+# Ubuntu as actual image base
+FROM ubuntu:22.04
+
+# Repeating args for context in this image
+ARG VULKAN_SDK_VERSION
+ARG SWIFTSHADER_VERSION
+
+ENV VULKAN_SDK="/VulkanSDK/${VULKAN_SDK_VERSION}/x86_64"
+ENV PATH="${VULKAN_SDK}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib"
+ENV VK_LAYER_PATH="${VULKAN_SDK}/etc/explicit_layer.d"
 
 # Base packages from default ppa
 RUN apt-get update -y
@@ -7,24 +25,23 @@ RUN apt-get install -y gnupg
 RUN apt-get install -y ca-certificates
 RUN apt-get install -y software-properties-common
 
-# Repository to latest cmake
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-
 # Repository for latest git (needed for gh actions)
 RUN add-apt-repository -y ppa:git-core/ppa
 
 # Refresh repositories
-RUN apt update -y
+RUN apt-get update -y --fix-missing
 
 RUN apt install -y git
-RUN apt-get install -y cmake g++
-RUN apt-get install -y libvulkan-dev
+RUN apt-get install -y gcc
+RUN apt-get install -y cmake
+RUN apt-get install -y g++
+
 # Swiftshader dependencies
 RUN apt-get install -y libx11-dev zlib1g-dev
 RUN apt-get install -y libxext-dev
 
-COPY --from=axsauze/swiftshader:0.1 /swiftshader/ /swiftshader/
+# Vulkan wayland client dependency
+RUN apt-get install -y libwayland-client0
 
 # GLSLANG tools for tests
 RUN apt-get install -y glslang-tools
@@ -32,7 +49,13 @@ RUN apt-get install -y glslang-tools
 # Setup Python
 RUN apt-get install -y python3-pip
 
+# Setup Node for nektos/act (local Github Actions) tests
+RUN apt-get install -y nodejs
+
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+COPY --from=vulkansdk-image ${VULKAN_SDK} ${VULKAN_SDK}
+COPY --from=swiftshader-image /swiftshader/ /swiftshader/
 
 RUN mkdir builder
 WORKDIR /builder

--- a/docker-builders/Makefile
+++ b/docker-builders/Makefile
@@ -1,18 +1,32 @@
 
-build_kompute_builder:
-	docker build .. -f KomputeBuilder.Dockerfile -t axsauze/kompute-builder:0.3
+KOMPUTE_BUILDER_VERSION=0.4
+SWIFTSHADER_VERSION=0.2
+VULKAN_SDK_VERSION=1.3.231.2
 
-push_kompute_builder: build_kompute_builder
-	docker push axsauze/kompute-builder:0.3
+build_kompute_builder:
+	docker build .. \
+		-f KomputeBuilder.Dockerfile \
+		--build-arg VULKAN_SDK_VERSION=$(VULKAN_SDK_VERSION) \
+		--build-arg SWIFTSHADER_VERSION=$(SWIFTSHADER_VERSION) \
+		-t axsauze/kompute-builder:${KOMPUTE_BUILDER_VERSION}
+
+push_kompute_builder:
+	docker push axsauze/kompute-builder:${KOMPUTE_BUILDER_VERSION}
 
 build_swiftshader:
-	docker build .. -f Swiftshader.Dockerfile -t axsauze/swiftshader:0.1
+	docker build .. \
+		-f Swiftshader.Dockerfile \
+		--build-arg VULKAN_SDK_VERSION=$(VULKAN_SDK_VERSION) \
+		-t axsauze/swiftshader:${SWIFTSHADER_VERSION}
 
-push_swiftshader: build_swiftshader
-	docker push axsauze/swiftshader:0.1
+push_swiftshader:
+	docker push axsauze/swiftshader:${SWIFTSHADER_VERSION}
 
 build_vulkan_sdk:
-	docker build .. -f VulkanSDK.Dockerfile -t axsauze/vulkan-sdk:0.1
+	docker build .. \
+		-f VulkanSDK.Dockerfile \
+		--build-arg VULKAN_SDK_VERSION=$(VULKAN_SDK_VERSION) \
+		-t axsauze/vulkan-sdk:${VULKAN_SDK_VERSION}
 
-push_vulkan_sdk: build_vulkan_sdk
-	docker push axsauze/vulkan-sdk:0.1
+push_vulkan_sdk:
+	docker push axsauze/vulkan-sdk:${VULKAN_SDK_VERSION}

--- a/docker-builders/Swiftshader.Dockerfile
+++ b/docker-builders/Swiftshader.Dockerfile
@@ -1,4 +1,14 @@
-FROM ubuntu:18.04
+
+ARG VULKAN_SDK_VERSION
+
+# Using FROM reference as COPY command doesn't support args
+FROM axsauze/vulkan-sdk:$VULKAN_SDK_VERSION as vulkansdk-image
+
+# Ubuntu as actual image base
+FROM ubuntu:22.04
+
+# Repeating ARG for context in this image
+ARG VULKAN_SDK_VERSION
 
 # Base packages from default ppa
 RUN apt-get update -y
@@ -7,28 +17,27 @@ RUN apt-get install -y gnupg
 RUN apt-get install -y ca-certificates
 RUN apt-get install -y software-properties-common
 
-# Repository to latest cmake
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-
-# Repository for latest git (needed for gh actions)
-RUN add-apt-repository -y ppa:git-core/ppa
-
-# Refresh repositories
-RUN apt update -y
-
+# Build dependencies
 RUN apt install -y git
 RUN apt-get install -y cmake g++
-RUN apt-get install -y libvulkan-dev
+
+# Setup Vulkan
+ENV VULKAN_SDK="/VulkanSDK/${VULKAN_SDK_VERSION}/x86_64"
+ENV PATH="${VULKAN_SDK}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib"
+ENV VK_LAYER_PATH="${VULKAN_SDK}/etc/explicit_layer.d"
+
+COPY --from=vulkansdk-image ${VULKAN_SDK} ${VULKAN_SDK}
 
 # Dependencies for swiftshader
-RUN apt-get install -y g++-8 gcc-8
+# RUN apt-get install -y g++-8 gcc-8
+RUN apt-get install -y gcc
 RUN apt-get install -y libx11-dev zlib1g-dev
 RUN apt-get install -y libxext-dev
 
 # Run swiftshader via env VK_ICD_FILENAMES=/swiftshader/vk_swiftshader_icd.json
 RUN git clone https://github.com/google/swiftshader swiftshader-build
-RUN CC="/usr/bin/gcc-8" CXX="/usr/bin/g++-8" cmake swiftshader-build/. -Bswiftshader-build/build/
-RUN cmake --build swiftshader-build/build/. --parallel
+RUN cmake swiftshader-build/. -Bswiftshader-build/build/
+RUN cmake --build swiftshader-build/build/. --parallel 8
 RUN cp -r swiftshader-build/build/Linux/ swiftshader/
 

--- a/docker-builders/Swiftshader.Dockerfile
+++ b/docker-builders/Swiftshader.Dockerfile
@@ -5,7 +5,7 @@ ARG VULKAN_SDK_VERSION
 FROM axsauze/vulkan-sdk:$VULKAN_SDK_VERSION as vulkansdk-image
 
 # Ubuntu as actual image base
-FROM ubuntu:22.04
+FROM ubuntu:22.04 as swiftshader-builder
 
 # Repeating ARG for context in this image
 ARG VULKAN_SDK_VERSION
@@ -40,4 +40,10 @@ RUN git clone https://github.com/google/swiftshader swiftshader-build
 RUN cmake swiftshader-build/. -Bswiftshader-build/build/
 RUN cmake --build swiftshader-build/build/. --parallel 8
 RUN cp -r swiftshader-build/build/Linux/ swiftshader/
+
+
+# Store build in slim down image
+FROM ubuntu:22.04
+
+COPY --from=swiftshader-builder /swiftshader/ /swiftshader/
 


### PR DESCRIPTION
Fixes  #265

Following from work on #302 focused on updating the build system to use Vulkan 1.3.x. This PR includes:

* Updating builder version to 1.3.212.2
* Ensuring builder uses Built VulkanSDK version
* Reducing size of Swiftshader (2gb->100mb) and VulkanSDK (16gb->2gb) images 
* Ensuring Kompute tests can be run locally using https://github.com/nektos/act
* Upgrade to ubuntu 22.04