### PR TITLE
Fixed build error on gcc 12

### DIFF
--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -3,6 +3,7 @@
 
 #include "kompute/Core.hpp"
 #include "logger/Logger.hpp"
+#include <memory>
 #include <string>
 
 namespace kp {


### PR DESCRIPTION
Steps to reproduce

$git clone https://github.com/KomputeProject/kompute.git $cmake -Bbuild
$cd build
$make

$gcc (SUSE Linux) 12.2.1 20221020 [revision 0aaef83351473e8f4eb774f8f999bbe87a4866d7] Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

 $lsb_release -a
LSB Version:    n/a
Distributor ID: openSUSE
Description:    openSUSE Tumbleweed
Release:        20221124
Codename:       n/a

Error log
In file included from /home/doof/gitrepo/kompute/src/include/kompute/operations/OpTensorCopy.hpp:6,
                 from /home/doof/gitrepo/kompute/src/OpTensorCopy.cpp:3:
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:55:27: error: expected ‘)’ before ‘<’ token
   55 |     Tensor(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
      |           ~               ^
      |                           )
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:108:30: error: ‘std::shared_ptr’ has not been declared
  108 |                         std::shared_ptr<Tensor> copyFromTensor);
      |                              ^~~~~~~~~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:108:40: error: expected ‘,’ or ‘...’ before ‘<’ token
  108 |                         std::shared_ptr<Tensor> copyFromTensor);
      |                                        ^
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:256:10: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  256 |     std::shared_ptr<vk::PhysicalDevice> mPhysicalDevice;
      |          ^~~~~~~~~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:6:1: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
    5 | #include "logger/Logger.hpp"
  +++ |+#include <memory>
    6 | #include <string>
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:257:10: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  257 |     std::shared_ptr<vk::Device> mDevice;
      |          ^~~~~~~~~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:257:5: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
  257 |     std::shared_ptr<vk::Device> mDevice;
      |     ^~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:260:10: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  260 |     std::shared_ptr<vk::Buffer> mPrimaryBuffer;
      |          ^~~~~~~~~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:260:5: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
  260 |     std::shared_ptr<vk::Buffer> mPrimaryBuffer;
      |     ^~~
/home/doof/gitrepo/kompute/src/include/kompute/Tensor.hpp:262:10: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
  262 |     std::shared_ptr<vk::Buffer> mStagingBuffer;

Final result

$make
[ 16%] Built target fmt
[ 27%] Built target kp_shader
[ 38%] Built target kp_logger
[ 44%] Building CXX object src/CMakeFiles/kompute.dir/Algorithm.cpp.o [ 50%] Building CXX object src/CMakeFiles/kompute.dir/Manager.cpp.o [ 55%] Building CXX object src/CMakeFiles/kompute.dir/OpAlgoDispatch.cpp.o [ 61%] Building CXX object src/CMakeFiles/kompute.dir/OpMemoryBarrier.cpp.o [ 66%] Building CXX object src/CMakeFiles/kompute.dir/OpTensorCopy.cpp.o [ 72%] Building CXX object src/CMakeFiles/kompute.dir/OpTensorSyncDevice.cpp.o [ 77%] Building CXX object src/CMakeFiles/kompute.dir/OpTensorSyncLocal.cpp.o [ 83%] Building CXX object src/CMakeFiles/kompute.dir/Sequence.cpp.o [ 88%] Building CXX object src/CMakeFiles/kompute.dir/Tensor.cpp.o [ 94%] Building CXX object src/CMakeFiles/kompute.dir/Core.cpp.o [100%] Linking CXX static library ../lib/libkompute.a [100%] Built target kompute

Fixes Issue #310