### PR TITLE
added support for custom kernel function names

### DIFF
--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -275,7 +275,7 @@ Algorithm::createPipeline()
       vk::PipelineShaderStageCreateFlags(),
       vk::ShaderStageFlagBits::eCompute,
       *this->mShaderModule,
-      "main",
+      this->mKernelFunctionName.c_str(),
       &specializationInfo);
 
     vk::ComputePipelineCreateInfo pipelineInfo(vk::PipelineCreateFlags(),

--- a/src/include/kompute/Algorithm.hpp
+++ b/src/include/kompute/Algorithm.hpp
@@ -40,11 +40,13 @@ class Algorithm
               const std::vector<uint32_t>& spirv = {},
               const Workgroup& workgroup = {},
               const std::vector<S>& specializationConstants = {},
-              const std::vector<P>& pushConstants = {})
+              const std::vector<P>& pushConstants = {},
+              const std::string& kernelFunctionName = "main")
     {
         KP_LOG_DEBUG("Kompute Algorithm Constructor with device");
 
         this->mDevice = device;
+        this->mKernelFunctionName = kernelFunctionName;
 
         if (tensors.size() && spirv.size()) {
             KP_LOG_INFO(
@@ -305,6 +307,7 @@ class Algorithm
     uint32_t mPushConstantsDataTypeMemorySize = 0;
     uint32_t mPushConstantsSize = 0;
     Workgroup mWorkgroup;
+    std::string mKernelFunctionName = "main";
 
     // Create util functions
     void createShaderModule();

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -144,10 +144,11 @@ class Manager
       const std::vector<uint32_t>& spirv = {},
       const Workgroup& workgroup = {},
       const std::vector<float>& specializationConstants = {},
-      const std::vector<float>& pushConstants = {})
+      const std::vector<float>& pushConstants = {},
+      const std::string& kernelFunctionName = "main")
     {
         return this->algorithm<>(
-          tensors, spirv, workgroup, specializationConstants, pushConstants);
+          tensors, spirv, workgroup, specializationConstants, pushConstants, kernelFunctionName);
     }
 
     /**
@@ -170,7 +171,8 @@ class Manager
       const std::vector<uint32_t>& spirv,
       const Workgroup& workgroup,
       const std::vector<S>& specializationConstants,
-      const std::vector<P>& pushConstants)
+      const std::vector<P>& pushConstants,
+      const std::string& kernelFunctionName = "main")
     {
 
         KP_LOG_DEBUG("Kompute Manager algorithm creation triggered");
@@ -181,7 +183,8 @@ class Manager
           spirv,
           workgroup,
           specializationConstants,
-          pushConstants) };
+          pushConstants,
+          kernelFunctionName) };
 
         if (this->mManageResources) {
             this->mManagedAlgorithms.push_back(algorithm);


### PR DESCRIPTION
In a response to Issue #251 , this PR aims to add support for custom function names (with which it becomes possible to use .spv shaders generated from openCL source files with the `clspv` tool). The only modification is to use a new field `mKernelFunctionName` instead of the hard-coded `"main"` constant that can be fed to the constructor of the `Algorithm` class as well as to the `algorithm` method of the `Manager` class. This parameter is added as the last one, with a default value of `"main"` so it should be completely backwards compatible. (As for openCL sources, it is forbidden to use `main` as the name of a kernel function, using such `spv` files without adding an explicit `asm("main")` suffix in the shader it was impossible, which is doable only if there is only one declared kernel function in the `cl` file so asm-hacking the name of the kernel function is not a complete solution.) 