### PR TITLE
Enhance Tensor Flexibility with Structs

### DIFF
--- a/examples/structure_array_multiplication/CMakeLists.txt
+++ b/examples/structure_array_multiplication/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.20)
+project(kompute_array_mult)
+include(CMakePrintHelpers)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# Options
+option(KOMPUTE_OPT_GIT_TAG "The tag of the repo to use for the example" "master")
+option(KOMPUTE_OPT_FROM_SOURCE "Whether to build example from source or from git fetch repo" 0)
+# Set a default build type if none was specified
+# Based on: https://github.com/openchemistry/tomviz/blob/master/cmake/BuildType.cmake
+set(DEFAULT_BUILD_TYPE "Release")
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    set(DEFAULT_BUILD_TYPE "Debug")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+if(WIN32) # Install dlls in the same directory as the executable on Windows
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
+
+if(KOMPUTE_OPT_FROM_SOURCE)
+    add_subdirectory(../../ ${CMAKE_CURRENT_BINARY_DIR}/kompute_build)
+else()
+    include(FetchContent)
+    FetchContent_Declare(kompute GIT_REPOSITORY https://github.com/KomputeProject/kompute.git
+        GIT_TAG ${KOMPUTE_OPT_GIT_TAG})
+    FetchContent_MakeAvailable(kompute)
+    include_directories(${kompute_SOURCE_DIR}/src/include)
+endif()
+
+# Add to the list, so CMake can later find the code to compile shaders to header files
+list(APPEND CMAKE_PREFIX_PATH "${kompute_SOURCE_DIR}/cmake")
+
+add_subdirectory(src/shaders) 
+add_subdirectory(src)

--- a/examples/structure_array_multiplication/README.md
+++ b/examples/structure_array_multiplication/README.md
@@ -1,0 +1,43 @@
+# Kompute Structure Array Multiplication Example
+
+This folder contains an Kompute Example demonstrating how to use structs between c++ and shaders. 
+
+## Building the example
+
+You will notice that it's a standalone project, so you can re-use it for your application.
+It uses CMake's [`fetch_content`](https://cmake.org/cmake/help/latest/module/FetchContent.html) to consume Kompute as a dependency.
+To build you just need to run the CMake command in this folder as follows:
+
+```bash
+git clone https://github.com/KomputeProject/kompute.git
+cd kompute/examples/structure_array_multiplication
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+
+## Executing
+
+Form inside the `build/` directory run:
+
+### Linux
+
+```bash
+./kompute_array_mult
+```
+
+### Windows
+
+```bash
+.\Debug\kompute_array_mult.exe
+```
+
+## Pre-requisites
+
+In order to run this example, you will need the following dependencies:
+
+* REQUIRED
+    + The Vulkan SDK must be installed
+
+For the Vulkan SDK, the simplest way to install it is through [their website](https://vulkan.lunarg.com/sdk/home). You just have to follow the instructions for the relevant platform.

--- a/examples/structure_array_multiplication/src/CMakeLists.txt
+++ b/examples/structure_array_multiplication/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.20)
+
+add_executable(kompute_array_mult main.cpp)
+target_link_libraries(kompute_array_mult PRIVATE shaders kompute::kompute)

--- a/examples/structure_array_multiplication/src/main.cpp
+++ b/examples/structure_array_multiplication/src/main.cpp
@@ -1,0 +1,71 @@
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include "SHADER_Mult1.hpp"
+#include <kompute/Kompute.hpp> 
+#include "shaders/structs/ExampleStructure2.hpp"
+
+int main()
+{
+    kp::Manager mgr; 
+
+    ExampleStructure2 a{ 1,2,3,4,5,6,7,8,9,10, {11,12,13,14,15,16,17,18,19,20} };
+    ExampleStructure2 b{ 1,2,3,4,5,6,7,8,9,10, {11,12,13,14,15,16,17,18,19,20} };
+    ExampleStructure2 c{ 0 };
+
+    std::shared_ptr<kp::TensorT<ExampleStructure2>> tensorInA =
+      mgr.tensorT<ExampleStructure2>({ a, b });
+    std::shared_ptr<kp::TensorT<ExampleStructure2>> tensorInB =
+      mgr.tensorT<ExampleStructure2>({ b, a });
+    std::shared_ptr<kp::TensorT<ExampleStructure2>> tensorOut =
+      mgr.tensorT<ExampleStructure2>({ c, c });
+
+    const std::vector<std::shared_ptr<kp::Tensor>> params = { tensorInA,
+                                                              tensorInB,
+                                                              tensorOut };
+
+    const std::vector<uint32_t> shader = std::vector<uint32_t>(
+        shaders::SHADER_MULT1_COMP_SPV.begin(), shaders::SHADER_MULT1_COMP_SPV.end());
+    std::shared_ptr<kp::Algorithm> algo = mgr.algorithm(params, shader);
+     
+    mgr.sequence()
+      ->record<kp::OpTensorSyncDevice>(params)
+      ->record<kp::OpAlgoDispatch>(algo)
+      ->record<kp::OpTensorSyncLocal>(params)
+      ->eval();
+
+    // prints "Output {  0  4  12  }"
+    std::cout << "Output: {  " << std::endl;
+    int i = 0;
+    for (const ExampleStructure2& elem : tensorOut->vector()) {
+        std::cout << "Elm " << i++ << ": ";
+        std::cout << elem.a << "  ";
+        std::cout << elem.b << "  ";
+        std::cout << elem.c << "  ";
+        std::cout << elem.d << "  ";
+        std::cout << elem.e << "  ";
+        std::cout << elem.f << "  ";
+        std::cout << elem.g << "  ";
+        std::cout << elem.h << "  ";
+        std::cout << elem.i << "  ";
+        std::cout << elem.j << "  ";
+
+        std::cout << "{" << "  ";
+
+        std::cout << elem.k.a << "  ";
+        std::cout << elem.k.b << "  ";
+        std::cout << elem.k.c << "  ";
+        std::cout << elem.k.d << "  ";
+        std::cout << elem.k.e << "  ";
+        std::cout << elem.k.f << "  ";
+        std::cout << elem.k.g << "  ";
+        std::cout << elem.k.h << "  ";
+        std::cout << elem.k.i << "  ";
+        std::cout << elem.k.j << "  ";
+
+        std::cout << "} " << std::endl;
+    }
+    std::cout << "}" << std::endl;
+}

--- a/examples/structure_array_multiplication/src/shaders/CMakeLists.txt
+++ b/examples/structure_array_multiplication/src/shaders/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+
+file(GLOB SHADERS *.comp)
+foreach(SHADER ${SHADERS})
+    get_filename_component(SHADER_NAME ${SHADER} NAME_WE)
+    set(OUTPUT_FILE_NO_EXT ${CMAKE_CURRENT_BINARY_DIR}/${SHADER_NAME})
+
+    vulkan_compile_shader(INFILE ${SHADER_NAME}.comp
+    OUTFILE ${SHADER_NAME}.hpp
+    NAMESPACE "shaders"
+    RELATIVE_PATH "${kompute_SOURCE_DIR}/cmake")
+
+    
+    list(APPEND SHADER_OUTPUTS ${OUTPUT_FILE_NO_EXT}.hpp) 
+endforeach()
+
+add_library(shaders INTERFACE  ${SHADER_OUTPUTS})
+target_include_directories(shaders INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)

--- a/examples/structure_array_multiplication/src/shaders/SHADER_Mult1.comp
+++ b/examples/structure_array_multiplication/src/shaders/SHADER_Mult1.comp
@@ -1,0 +1,45 @@
+#version 450
+#extension GL_GOOGLE_include_directive : require
+#include "structs/ExampleStructure2.hpp"
+
+layout (local_size_x = 1) in;
+
+layout (std430, binding = 0) buffer bufA {
+    ExampleStructure2 A[];
+};
+
+layout (std430, binding = 1) buffer bufB {
+    ExampleStructure2 B[];
+};
+
+layout (std430, binding = 2) buffer bufOut {
+    ExampleStructure2 Out[];
+};
+
+void main() {
+    uint id = gl_GlobalInvocationID.x;
+
+    //example structure2
+    Out[id].a = A[id].a * B[id].a;
+    Out[id].b = A[id].b * B[id].b;
+    Out[id].c = A[id].c * B[id].c;
+    Out[id].d = A[id].d * B[id].d;
+    Out[id].e = A[id].e * B[id].e;
+    Out[id].f = A[id].f * B[id].f;
+    Out[id].g = A[id].g * B[id].g;
+    Out[id].h = A[id].h * B[id].h;
+    Out[id].i = A[id].i * B[id].i;
+    Out[id].j = A[id].j * B[id].j;
+
+    //example structure1(nested struct)
+    Out[id].k.a = A[id].k.a * B[id].k.a;
+    Out[id].k.b = A[id].k.b * B[id].k.b;
+    Out[id].k.c = A[id].k.c * B[id].k.c;
+    Out[id].k.d = A[id].k.d * B[id].k.d;
+    Out[id].k.e = A[id].k.e * B[id].k.e;
+    Out[id].k.f = A[id].k.f * B[id].k.f;
+    Out[id].k.g = A[id].k.g * B[id].k.g;
+    Out[id].k.h = A[id].k.h * B[id].k.h;
+    Out[id].k.i = A[id].k.i * B[id].k.i;
+    Out[id].k.j = A[id].k.j * B[id].k.j;
+}

--- a/examples/structure_array_multiplication/src/shaders/structs/ExampleStructure1.hpp
+++ b/examples/structure_array_multiplication/src/shaders/structs/ExampleStructure1.hpp
@@ -1,0 +1,28 @@
+#ifndef EXAMPLE_STRUCTURE_1_HPP
+#define EXAMPLE_STRUCTURE_1_HPP
+
+#if defined(__clang__) || defined(_MSC_VER) || defined(__ICC) || defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__)
+//c++ compiler
+#else
+//shader comipler
+#extension GL_GOOGLE_include_directive : require
+#endif
+
+#include "StructTemplate.hpp"
+
+struct ExampleStructure1
+{
+    int8_t    a;
+    int16_t   b;
+    int32_t   c;
+    int64_t   d;
+
+    uint8_t   e;
+    uint16_t  f;
+    uint32_t  g;
+    uint64_t  h;
+
+    float32_t i;
+    float64_t j;
+};
+#endif

--- a/examples/structure_array_multiplication/src/shaders/structs/ExampleStructure2.hpp
+++ b/examples/structure_array_multiplication/src/shaders/structs/ExampleStructure2.hpp
@@ -1,0 +1,31 @@
+#ifndef EXAMPLE_STRUCTURE_2_HPP
+#define EXAMPLE_STRUCTURE_2_HPP
+
+#if defined(__clang__) || defined(_MSC_VER) || defined(__ICC) || defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__)
+//c++ compiler
+#else
+//shader comipler
+#extension GL_GOOGLE_include_directive : require
+#endif
+
+#include "StructTemplate.hpp"
+#include "ExampleStructure1.hpp"
+
+struct ExampleStructure2
+{
+    int8_t    a;
+    int16_t   b;
+    int32_t   c;
+    int64_t   d;
+
+    uint8_t   e;
+    uint16_t  f;
+    uint32_t  g;
+    uint64_t  h;
+
+    float32_t i;
+    float64_t j;
+    ExampleStructure1 k;
+};
+#endif
+

--- a/examples/structure_array_multiplication/src/shaders/structs/StructTemplate.hpp
+++ b/examples/structure_array_multiplication/src/shaders/structs/StructTemplate.hpp
@@ -1,0 +1,24 @@
+#if defined(__clang__) || defined(_MSC_VER) || defined(__ICC) || defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__)
+//c++ compiler
+typedef signed char        int8_t;
+typedef short              int16_t;
+typedef int                int32_t;
+typedef long long          int64_t;
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef float float32_t;
+typedef double float64_t;
+#else
+//shader comipler
+#extension GL_EXT_shader_explicit_arithmetic_types_int8    : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16   : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int32   : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int64   : require
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float32 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float64 : require
+#endif

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -258,34 +258,25 @@ PYBIND11_MODULE(kp, m)
                          flatdata.size(),
                          std::string(py::str(flatdata.dtype())));
             if (flatdata.dtype().is(py::dtype::of<std::float_t>())) {
-                return self.tensor(info.ptr,
+                return self.tensor<float>(info.ptr,
                                    flatdata.size(),
-                                   sizeof(float),
-                                   kp::Tensor::TensorDataTypes::eFloat,
                                    tensor_type);
             } else if (flatdata.dtype().is(py::dtype::of<std::uint32_t>())) {
-                return self.tensor(info.ptr,
+                return self.tensor<uint32_t>(
+                                   info.ptr,
                                    flatdata.size(),
-                                   sizeof(uint32_t),
-                                   kp::Tensor::TensorDataTypes::eUnsignedInt,
                                    tensor_type);
             } else if (flatdata.dtype().is(py::dtype::of<std::int32_t>())) {
-                return self.tensor(info.ptr,
+                return self.tensor<int32_t>(info.ptr,
                                    flatdata.size(),
-                                   sizeof(int32_t),
-                                   kp::Tensor::TensorDataTypes::eInt,
                                    tensor_type);
             } else if (flatdata.dtype().is(py::dtype::of<std::double_t>())) {
-                return self.tensor(info.ptr,
+                return self.tensor<double>(info.ptr,
                                    flatdata.size(),
-                                   sizeof(double),
-                                   kp::Tensor::TensorDataTypes::eDouble,
                                    tensor_type);
             } else if (flatdata.dtype().is(py::dtype::of<bool>())) {
-                return self.tensor(info.ptr,
+                return self.tensor<bool>(info.ptr,
                                    flatdata.size(),
-                                   sizeof(bool),
-                                   kp::Tensor::TensorDataTypes::eBool,
                                    tensor_type);
             } else {
                 throw std::runtime_error(

--- a/src/OpTensorCopy.cpp
+++ b/src/OpTensorCopy.cpp
@@ -2,6 +2,7 @@
 
 #include "kompute/operations/OpTensorCopy.hpp"
 #include "kompute/Tensor.hpp"
+#include <typeinfo>
 
 namespace kp {
 
@@ -16,7 +17,7 @@ OpTensorCopy::OpTensorCopy(const std::vector<std::shared_ptr<Tensor>>& tensors)
           "Kompute OpTensorCopy called with less than 2 tensor");
     }
 
-    kp::Tensor::TensorDataTypes dataType = this->mTensors[0]->dataType();
+    const std::type_info& dataType = this->mTensors[0]->dataType();
     uint32_t size = this->mTensors[0]->size();
     for (const std::shared_ptr<Tensor>& tensor : tensors) {
         if (tensor->dataType() != dataType) {

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -1,26 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kompute/Tensor.hpp"
+#include <typeinfo>
 
 namespace kp {
 
 std::string
-Tensor::toString(Tensor::TensorDataTypes dt)
+Tensor::toString(const std::type_info& dt)
 {
-    switch (dt) {
-        case TensorDataTypes::eBool:
-            return "eBool";
-        case TensorDataTypes::eInt:
-            return "eInt";
-        case TensorDataTypes::eUnsignedInt:
-            return "eUnsignedInt";
-        case TensorDataTypes::eFloat:
-            return "eFloat";
-        case TensorDataTypes::eDouble:
-            return "eDouble";
-        default:
-            return "unknown";
-    }
+    return dt.name();
 }
 
 std::string
@@ -43,8 +31,9 @@ Tensor::Tensor(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
                void* data,
                uint32_t elementTotalCount,
                uint32_t elementMemorySize,
-               const TensorDataTypes& dataType,
+               const std::type_info& dataType,
                const TensorTypes& tensorType)
+  : mDataType(dataType)
 {
     KP_LOG_DEBUG("Kompute Tensor constructor data length: {}, and type: {}",
                  elementTotalCount,
@@ -52,7 +41,6 @@ Tensor::Tensor(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
 
     this->mPhysicalDevice = physicalDevice;
     this->mDevice = device;
-    this->mDataType = dataType;
     this->mTensorType = tensorType;
 
     this->rebuild(data, elementTotalCount, elementMemorySize);
@@ -125,7 +113,7 @@ Tensor::memorySize()
     return this->mSize * this->mDataTypeMemorySize;
 }
 
-kp::Tensor::TensorDataTypes
+const std::type_info&
 Tensor::dataType()
 {
     return this->mDataType;
@@ -588,40 +576,4 @@ Tensor::destroy()
 
     KP_LOG_DEBUG("Kompute Tensor successful destroy()");
 }
-
-template<>
-Tensor::TensorDataTypes
-TensorT<bool>::dataType()
-{
-    return Tensor::TensorDataTypes::eBool;
-}
-
-template<>
-Tensor::TensorDataTypes
-TensorT<int32_t>::dataType()
-{
-    return Tensor::TensorDataTypes::eInt;
-}
-
-template<>
-Tensor::TensorDataTypes
-TensorT<uint32_t>::dataType()
-{
-    return Tensor::TensorDataTypes::eUnsignedInt;
-}
-
-template<>
-Tensor::TensorDataTypes
-TensorT<float>::dataType()
-{
-    return Tensor::TensorDataTypes::eFloat;
-}
-
-template<>
-Tensor::TensorDataTypes
-TensorT<double>::dataType()
-{
-    return Tensor::TensorDataTypes::eDouble;
-}
-
 }

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -3,6 +3,7 @@
 
 #include <set>
 #include <unordered_map>
+#include <typeinfo>
 
 #include "kompute/Core.hpp"
 
@@ -102,11 +103,24 @@ class Manager
         return this->tensorT<float>(data, tensorType);
     }
 
+    template<typename T>
+    std::shared_ptr<Tensor> tensor(
+      void* data,
+      uint32_t elementTotalCount,
+      Tensor::TensorTypes tensorType = Tensor::TensorTypes::eDevice)
+    {
+        return tensor(data,
+                      elementTotalCount,
+                      sizeof(T),
+                      typeid(T),
+                      tensorType);
+    }
+
     std::shared_ptr<Tensor> tensor(
       void* data,
       uint32_t elementTotalCount,
       uint32_t elementMemorySize,
-      const Tensor::TensorDataTypes& dataType,
+      const std::type_info& dataType,
       Tensor::TensorTypes tensorType = Tensor::TensorTypes::eDevice)
     {
         std::shared_ptr<Tensor> tensor{ new kp::Tensor(this->mPhysicalDevice,

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -5,6 +5,7 @@
 #include "logger/Logger.hpp"
 #include <memory>
 #include <string>
+#include <typeinfo>
 
 namespace kp {
 
@@ -31,16 +32,8 @@ class Tensor
         eHost = 1,    ///< Type is host memory, source and destination
         eStorage = 2, ///< Type is Device memory (only)
     };
-    enum class TensorDataTypes
-    {
-        eBool = 0,
-        eInt = 1,
-        eUnsignedInt = 2,
-        eFloat = 3,
-        eDouble = 4,
-    };
 
-    static std::string toString(TensorDataTypes dt);
+    static std::string toString(const std::type_info& dt);
     static std::string toString(TensorTypes dt);
 
     /**
@@ -58,7 +51,7 @@ class Tensor
            void* data,
            uint32_t elementTotalCount,
            uint32_t elementMemorySize,
-           const TensorDataTypes& dataType,
+           const std::type_info& dataType,
            const TensorTypes& tensorType = TensorTypes::eDevice);
 
     /**
@@ -201,7 +194,7 @@ class Tensor
      *
      * @return Data type of tensor of type kp::Tensor::TensorDataTypes
      */
-    TensorDataTypes dataType();
+    const std::type_info& dataType();
 
     /**
      * Retrieve the raw data via the pointer to the memory that contains the raw
@@ -247,7 +240,7 @@ class Tensor
   protected:
     // -------------- ALWAYS OWNED RESOURCES
     TensorTypes mTensorType;
-    TensorDataTypes mDataType;
+    const std::type_info& mDataType;
     uint32_t mSize;
     uint32_t mDataTypeMemorySize;
     void* mRawData;
@@ -341,7 +334,10 @@ class TensorT : public Tensor
         Tensor::setRawData(data.data());
     }
 
-    TensorDataTypes dataType();
+    const std::type_info& dataType() 
+    { 
+        return typeid(T);
+    }
 };
 
 } // End namespace kp

--- a/test/TestTensor.cpp
+++ b/test/TestTensor.cpp
@@ -22,25 +22,24 @@ TEST(TestTensor, DataTypes)
     {
         std::vector<float> vec{ 0, 1, 2 };
         std::shared_ptr<kp::TensorT<float>> tensor = mgr.tensor(vec);
-        EXPECT_EQ(tensor->dataType(), kp::Tensor::TensorDataTypes::eFloat);
+        EXPECT_EQ(tensor->dataType(), typeid(float));
     }
 
     {
         std::vector<int32_t> vec{ 0, 1, 2 };
         std::shared_ptr<kp::TensorT<int32_t>> tensor = mgr.tensorT(vec);
-        EXPECT_EQ(tensor->dataType(), kp::Tensor::TensorDataTypes::eInt);
+        EXPECT_EQ(tensor->dataType(), typeid(int32_t));
     }
 
     {
         std::vector<uint32_t> vec{ 0, 1, 2 };
         std::shared_ptr<kp::TensorT<uint32_t>> tensor = mgr.tensorT(vec);
-        EXPECT_EQ(tensor->dataType(),
-                  kp::Tensor::TensorDataTypes::eUnsignedInt);
+        EXPECT_EQ(tensor->dataType(), typeid(uint32_t));
     }
 
     {
         std::vector<double> vec{ 0, 1, 2 };
         std::shared_ptr<kp::TensorT<double>> tensor = mgr.tensorT(vec);
-        EXPECT_EQ(tensor->dataType(), kp::Tensor::TensorDataTypes::eDouble);
+        EXPECT_EQ(tensor->dataType(), typeid(double));
     }
 }


### PR DESCRIPTION
replaces kp::Tensor::TensorDataTypes with std::type_info. This allows you to use any struct as a tensor rather than being limited by base datatypes (int, uint, float, etc..).

The easiest way I found to use structs in shaders is to use the "GL_GOOGLE_include_directive" extension to include a hpp file that holds the struct. this way you can use the struct in your shader code and c++ code. (see new example)