### PR TITLE
[performance bug] Fix Sequence::clear()

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -84,6 +84,7 @@ void
 Sequence::clear()
 {
     KP_LOG_DEBUG("Kompute Sequence calling clear");
+    this->mOperations.clear();
     if (this->isRecording()) {
         this->end();
     }


### PR DESCRIPTION
Hey, I noticed a performance degradation over time 
when repeatedly calling `Sequence::eval(..)` or `Sequence::evalAsync(..)`.

Both functions first clear the currently recorded operations by calling `Sequence::clear()`, 
then record and actually evaluate the new operation.

The problem is - `Sequence::clear()` never actually clears the operations.
This leads to operations just adding up.

This PR simply adds the missing clear call.
I guess this was just an oversight...
I only noticed this problem only in a compute heavy, long running process.