### PR TITLE
Support custom parameter in sequence template functions

### DIFF
--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -41,7 +41,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * function also requires the Sequence to be recording, otherwise it will
      * not be able to add the operation.
      *
-     * @param op Object derived from kp::BaseOp that will be recoreded by the
+     * @param op Object derived from kp::BaseOp that will be recorded by the
      * sequence which will be used when the operation is evaluated.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
@@ -53,37 +53,18 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * function also requires the Sequence to be recording, otherwise it will
      * not be able to add the operation.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
     std::shared_ptr<Sequence> record(
-      std::vector<std::shared_ptr<Tensor>> tensors,
+      typename T::ConstructorParameterType param,
       TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->record(op);
-    }
-    /**
-     * Record function for operation to be added to the GPU queue in batch. This
-     * template requires classes to be derived from the OpBase class. This
-     * function also requires the Sequence to be recording, otherwise it will
-     * not be able to add the operation.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> record(std::shared_ptr<Algorithm> algorithm,
-                                     TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->record(op);
     }
 
@@ -108,34 +89,18 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> eval(std::vector<std::shared_ptr<Tensor>> tensors,
-                                   TArgs&&... params)
+    std::shared_ptr<Sequence> eval(
+      typename T::ConstructorParameterType param,
+      TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->eval(op);
-    }
-    /**
-     * Eval sends all the recorded and stored operations in the vector of
-     * operations into the gpu as a submit job with a barrier.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> eval(std::shared_ptr<Algorithm> algorithm,
-                                   TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->eval(op);
     }
 
@@ -148,6 +113,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync();
+
     /**
      * Clears currnet operations to record provided one in the vector of
      * operations into the gpu as a submit job without a barrier. EvalAwait()
@@ -157,39 +123,23 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync(std::shared_ptr<OpBase> op);
+
     /**
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
     std::shared_ptr<Sequence> evalAsync(
-      std::vector<std::shared_ptr<Tensor>> tensors,
+      typename T::ConstructorParameterType param,
       TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->evalAsync(op);
-    }
-    /**
-     * Eval sends all the recorded and stored operations in the vector of
-     * operations into the gpu as a submit job with a barrier.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> evalAsync(std::shared_ptr<Algorithm> algorithm,
-                                        TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->evalAsync(op);
     }
 

--- a/src/include/kompute/operations/OpAlgoDispatch.hpp
+++ b/src/include/kompute/operations/OpAlgoDispatch.hpp
@@ -17,6 +17,8 @@ namespace kp {
 class OpAlgoDispatch : public OpBase
 {
   public:
+    using ConstructorParameterType = std::shared_ptr<kp::Algorithm>;
+
     /**
      * Constructor that stores the algorithm to use as well as the relevant
      * push constants to override when recording.

--- a/src/include/kompute/operations/OpBase.hpp
+++ b/src/include/kompute/operations/OpBase.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpBase
 {
   public:
+    using ConstructorParameterType = void;
+
     /**
      * Default destructor for OpBase class. This OpBase destructor class should
      * always be called to destroy and free owned resources unless it is

--- a/src/include/kompute/operations/OpMemoryBarrier.hpp
+++ b/src/include/kompute/operations/OpMemoryBarrier.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpMemoryBarrier : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+
     /**
      * Constructor that stores tensors as well as memory barrier parameters to
      * be used to create a pipeline barrier on the respective primary or staging

--- a/src/include/kompute/operations/OpMult.hpp
+++ b/src/include/kompute/operations/OpMult.hpp
@@ -21,6 +21,8 @@ namespace kp {
 class OpMult : public OpAlgoDispatch
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the bare minimum
      * requirements for the operations to be able to create and manage their

--- a/src/include/kompute/operations/OpTensorCopy.hpp
+++ b/src/include/kompute/operations/OpTensorCopy.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpTensorCopy : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation.

--- a/src/include/kompute/operations/OpTensorSyncDevice.hpp
+++ b/src/include/kompute/operations/OpTensorSyncDevice.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpTensorSyncDevice : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation. The tensos

--- a/src/include/kompute/operations/OpTensorSyncLocal.hpp
+++ b/src/include/kompute/operations/OpTensorSyncLocal.hpp
@@ -20,6 +20,8 @@ namespace kp {
 class OpTensorSyncLocal : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation. The tensors


### PR DESCRIPTION
This PR enables custom parameters in the template functions `sequence.record(..)`, `sequence.eval(..)` and `sequence.evalAsync(..)` by replacing the specializations with a more generic approach.

In theory the compiler should be able to deduce the correct Constructor of the passed Operation class if there is just one. However it seems to require at least the first argument type to correctly deduce the constructor when given an initializer list like `eval<op>({...})`.
Currently this done with template specializations that passes either `std::vector<std::shared_ptr<Tensor>> tensors` or `std::shared_ptr<Algorithm> algorithm` to disambiguate the templates.

I found a way to supply this first parameter type through the respective Operations class itself, rather than hard-coding them as template specializations.
This makes the code a little compacter, but more importantly it allows custom user operations to use the same template and thus, nice syntax.

This turns
```C++
std::shared_ptr<OpCustom> op{ new OpCustom({CustomParameter}) };
sequence->eval(op);
```
into
```C++
sequence->eval<OpCustom>({CustomParameter});
```

The only change to existing operations is the addition of the first constructor type to each class.
The current functionality is not changed otherwise.
