### PR TITLE
Add tensor copy operations with region support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,9 @@ add_library(kompute Algorithm.cpp
     OpTensorCopy.cpp
     OpTensorSyncDevice.cpp
     OpTensorSyncLocal.cpp
+    OpTensorCopyRegion.cpp
+    OpTensorSyncRegionDevice.cpp
+    OpTensorSyncRegionLocal.cpp
     Sequence.cpp
     Tensor.cpp
     Core.cpp)

--- a/src/OpTensorCopyRegion.cpp
+++ b/src/OpTensorCopyRegion.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "kompute/operations/OpTensorCopyRegion.hpp"
+#include "kompute/Tensor.hpp"
+
+namespace kp {
+
+OpTensorCopyRegion::OpTensorCopyRegion(const TensorCopyRegions regions)
+{
+    KP_LOG_DEBUG("Kompute OpTensorCopyRegion constructor with params");
+
+    if (regions.dstRegions.size() < 1) {
+        throw std::runtime_error(
+          "Kompute OpTensorCopyRegion called with no destination region");
+    }
+
+    kp::Tensor::TensorDataTypes dataType = regions.srcTensor->dataType();
+    for (const TensorRegion& region : regions.dstRegions) {
+        if (region.tensor->dataType() != dataType) {
+            throw std::runtime_error(fmt::format(
+              "Kompute OpTensorCopyRegion called with different types from {} to {}",
+              Tensor::toString(dataType),
+              Tensor::toString(region.tensor->dataType())));
+        }
+        if (region.elemCount == 0) {
+            throw std::runtime_error(
+                "Kompute OpTensorCopyRegion called with elemCount == 0");
+        }
+        if (region.srcIndex + region.elemCount > regions.srcTensor->size()) {
+            throw std::runtime_error(
+                "Kompute OpTensorCopyRegion called with out of bounds source region");
+        }
+        if (region.dstIndex  + region.elemCount > region.tensor->size()) {
+            throw std::runtime_error(
+                "Kompute OpTensorCopyRegion called with out of bounds destination region");
+        }     
+    }
+
+    this->mRegions = regions;
+}
+
+OpTensorCopyRegion::~OpTensorCopyRegion()
+{
+    KP_LOG_DEBUG("Kompute OpTensorCopyRegion destructor started");
+}
+
+void
+OpTensorCopyRegion::record(const vk::CommandBuffer& commandBuffer)
+{
+    KP_LOG_DEBUG("Kompute OpTensorCopyRegion record called");
+
+    for (size_t i = 0; i < this->mRegions.dstRegions.size(); i++) {
+        const uint32_t dataTypeMemorySize = this->mRegions.dstRegions[i].tensor->dataTypeMemorySize();
+        const vk::BufferCopy copy = {
+            dataTypeMemorySize * this->mRegions.dstRegions[i].srcIndex,
+            dataTypeMemorySize * this->mRegions.dstRegions[i].dstIndex,
+            dataTypeMemorySize * this->mRegions.dstRegions[i].elemCount,
+        };
+        this->mRegions.dstRegions[i].tensor->recordCopyFrom(commandBuffer, this->mRegions.srcTensor, copy);
+    }
+}
+
+void
+OpTensorCopyRegion::preEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorCopyRegion preEval called");
+}
+
+void
+OpTensorCopyRegion::postEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorCopyRegion postEval called");
+}
+
+}

--- a/src/OpTensorSyncRegionDevice.cpp
+++ b/src/OpTensorSyncRegionDevice.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "kompute/operations/OpTensorSyncRegionDevice.hpp"
+
+namespace kp {
+
+OpTensorSyncRegionDevice::OpTensorSyncRegionDevice(
+  const std::vector<TensorRegion>& regions)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionDevice constructor with params");
+
+    if (regions.size() < 1) {
+        throw std::runtime_error(
+          "Kompute OpTensorSyncRegionDevice called with less than 1 tensor region");
+    }
+
+    for (size_t i = 0; i < regions.size(); i++) {
+        if (regions[i].elemCount == 0) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionDevice called with elemCount == 0");
+        }
+        if (regions[i].srcIndex + regions[i].elemCount > regions[i].tensor->size()) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionDevice called with out of bounds source region");
+        }
+        if (regions[i].dstIndex  + regions[i].elemCount > regions[i].tensor->size()) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionDevice called with out of bounds destination region");
+        }        
+    }
+
+    this->mRegions = regions;
+}
+
+OpTensorSyncRegionDevice::~OpTensorSyncRegionDevice()
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionDevice destructor started");
+
+    this->mRegions.clear();
+}
+
+void
+OpTensorSyncRegionDevice::record(const vk::CommandBuffer& commandBuffer)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionDevice record called");
+
+    for (size_t i = 0; i < this->mRegions.size(); i++) {
+        if (this->mRegions[i].tensor->tensorType() == Tensor::TensorTypes::eDevice) {
+            const uint32_t dataTypeMemorySize = this->mRegions[i].tensor->dataTypeMemorySize();
+            const vk::BufferCopy copy = {
+                dataTypeMemorySize * this->mRegions[i].srcIndex,
+                dataTypeMemorySize * this->mRegions[i].dstIndex,
+                dataTypeMemorySize * this->mRegions[i].elemCount,
+            };
+            this->mRegions[i].tensor->recordCopyFromStagingToDevice(commandBuffer, copy);
+        }
+    }
+}
+
+void
+OpTensorSyncRegionDevice::preEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionDevice preEval called");
+}
+
+void
+OpTensorSyncRegionDevice::postEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionDevice postEval called");
+}
+
+}

--- a/src/OpTensorSyncRegionLocal.cpp
+++ b/src/OpTensorSyncRegionLocal.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "kompute/Tensor.hpp"
+
+#include "kompute/operations/OpTensorSyncRegionLocal.hpp"
+
+namespace kp {
+
+OpTensorSyncRegionLocal::OpTensorSyncRegionLocal(
+  const std::vector<TensorRegion>& regions)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal constructor with params");
+
+    if (regions.size() < 1) {
+        throw std::runtime_error(
+          "Kompute OpTensorSyncRegionLocal called with less than 1 region");
+    }
+
+    for (size_t i = 0; i < regions.size(); i++) {
+        if (regions[i].elemCount == 0) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionLocal called with elemCount == 0");
+        }
+        if (regions[i].srcIndex + regions[i].elemCount > regions[i].tensor->size()) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionLocal called with out of bounds source region");
+        }
+        if (regions[i].dstIndex  + regions[i].elemCount > regions[i].tensor->size()) {
+            throw std::runtime_error(
+            "Kompute OpTensorSyncRegionLocal called with out of bounds destination region");
+        }        
+    }
+
+    this->mRegions = regions;
+}
+
+OpTensorSyncRegionLocal::~OpTensorSyncRegionLocal()
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal destructor started");
+}
+
+void
+OpTensorSyncRegionLocal::record(const vk::CommandBuffer& commandBuffer)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal record called");
+
+    for (size_t i = 0; i < this->mRegions.size(); i++) {
+        if (this->mRegions[i].tensor->tensorType() == Tensor::TensorTypes::eDevice) {
+
+            this->mRegions[i].tensor->recordPrimaryBufferMemoryBarrier(
+              commandBuffer,
+              vk::AccessFlagBits::eShaderWrite,
+              vk::AccessFlagBits::eTransferRead,
+              vk::PipelineStageFlagBits::eComputeShader,
+              vk::PipelineStageFlagBits::eTransfer);
+
+            const uint32_t dataTypeMemorySize = this->mRegions[i].tensor->dataTypeMemorySize();
+            const vk::BufferCopy copy = {
+                dataTypeMemorySize * this->mRegions[i].srcIndex,
+                dataTypeMemorySize * this->mRegions[i].dstIndex,
+                dataTypeMemorySize * this->mRegions[i].elemCount,
+            };
+            this->mRegions[i].tensor->recordCopyFromDeviceToStaging(commandBuffer, copy);
+
+            this->mRegions[i].tensor->recordPrimaryBufferMemoryBarrier(
+              commandBuffer,
+              vk::AccessFlagBits::eTransferWrite,
+              vk::AccessFlagBits::eHostRead,
+              vk::PipelineStageFlagBits::eTransfer,
+              vk::PipelineStageFlagBits::eHost);
+        }
+    }
+}
+
+void
+OpTensorSyncRegionLocal::preEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal preEval called");
+}
+
+void
+OpTensorSyncRegionLocal::postEval(const vk::CommandBuffer& /*commandBuffer*/)
+{
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal postEval called");
+
+    KP_LOG_DEBUG("Kompute OpTensorSyncRegionLocal mapping data into tensor local");
+}
+
+}

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -202,7 +202,20 @@ Tensor::recordCopyFrom(const vk::CommandBuffer& commandBuffer,
     vk::DeviceSize bufferSize(this->memorySize());
     vk::BufferCopy copyRegion(0, 0, bufferSize);
 
-    KP_LOG_DEBUG("Kompute Tensor recordCopyFrom data size {}.", bufferSize);
+    this->recordCopyFrom(commandBuffer,
+                           copyFromTensor,
+                           copyRegion);
+}
+
+void
+Tensor::recordCopyFrom(const vk::CommandBuffer& commandBuffer,
+                       std::shared_ptr<Tensor> copyFromTensor,
+                       const vk::BufferCopy copyRegion)
+{
+
+    vk::DeviceSize bufferSize(this->memorySize());
+
+    KP_LOG_DEBUG("Kompute Tensor recordCopyFrom data size {}.", copyRegion.size);
 
     this->recordCopyBuffer(commandBuffer,
                            copyFromTensor->mPrimaryBuffer,
@@ -217,7 +230,15 @@ Tensor::recordCopyFromStagingToDevice(const vk::CommandBuffer& commandBuffer)
     vk::DeviceSize bufferSize(this->memorySize());
     vk::BufferCopy copyRegion(0, 0, bufferSize);
 
-    KP_LOG_DEBUG("Kompute Tensor copying data size {}.", bufferSize);
+    this->recordCopyFromStagingToDevice(commandBuffer, copyRegion);
+}
+
+void
+Tensor::recordCopyFromStagingToDevice(const vk::CommandBuffer& commandBuffer, const vk::BufferCopy copyRegion)
+{
+    vk::DeviceSize bufferSize(this->memorySize());
+
+    KP_LOG_DEBUG("Kompute Tensor copying data size {}.", copyRegion.size);
 
     this->recordCopyBuffer(commandBuffer,
                            this->mStagingBuffer,
@@ -232,7 +253,17 @@ Tensor::recordCopyFromDeviceToStaging(const vk::CommandBuffer& commandBuffer)
     vk::DeviceSize bufferSize(this->memorySize());
     vk::BufferCopy copyRegion(0, 0, bufferSize);
 
-    KP_LOG_DEBUG("Kompute Tensor copying data size {}.", bufferSize);
+    this->recordCopyFromDeviceToStaging(commandBuffer,
+                                        copyRegion);
+}
+
+void
+Tensor::recordCopyFromDeviceToStaging(const vk::CommandBuffer& commandBuffer,
+                                      const vk::BufferCopy copyRegion)
+{
+    vk::DeviceSize bufferSize(this->memorySize());
+
+    KP_LOG_DEBUG("Kompute Tensor copying data size {}.", copyRegion.size);
 
     this->recordCopyBuffer(commandBuffer,
                            this->mPrimaryBuffer,

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -23,6 +23,9 @@ target_sources(kompute PRIVATE
     kompute/operations/OpTensorCopy.hpp
     kompute/operations/OpTensorSyncDevice.hpp
     kompute/operations/OpTensorSyncLocal.hpp
+    kompute/operations/OpTensorCopyRegion.hpp
+    kompute/operations/OpTensorSyncRegionDevice.hpp
+    kompute/operations/OpTensorSyncRegionLocal.hpp
 
     kompute/logger/Logger.hpp
 )

--- a/src/include/kompute/Kompute.hpp
+++ b/src/include/kompute/Kompute.hpp
@@ -13,6 +13,9 @@
 #include "operations/OpTensorCopy.hpp"
 #include "operations/OpTensorSyncDevice.hpp"
 #include "operations/OpTensorSyncLocal.hpp"
+#include "operations/OpTensorCopyRegion.hpp"
+#include "operations/OpTensorSyncRegionDevice.hpp"
+#include "operations/OpTensorSyncRegionLocal.hpp"
 
 // Will be build by CMake and placed inside the build directory
 #include "ShaderLogisticRegression.hpp"

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -41,7 +41,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * function also requires the Sequence to be recording, otherwise it will
      * not be able to add the operation.
      *
-     * @param op Object derived from kp::BaseOp that will be recoreded by the
+     * @param op Object derived from kp::BaseOp that will be recorded by the
      * sequence which will be used when the operation is evaluated.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
@@ -53,37 +53,18 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * function also requires the Sequence to be recording, otherwise it will
      * not be able to add the operation.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
     std::shared_ptr<Sequence> record(
-      std::vector<std::shared_ptr<Tensor>> tensors,
+      typename T::ConstructorParameterType param,
       TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->record(op);
-    }
-    /**
-     * Record function for operation to be added to the GPU queue in batch. This
-     * template requires classes to be derived from the OpBase class. This
-     * function also requires the Sequence to be recording, otherwise it will
-     * not be able to add the operation.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> record(std::shared_ptr<Algorithm> algorithm,
-                                     TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->record(op);
     }
 
@@ -108,34 +89,18 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> eval(std::vector<std::shared_ptr<Tensor>> tensors,
-                                   TArgs&&... params)
+    std::shared_ptr<Sequence> eval(
+      typename T::ConstructorParameterType param,
+      TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->eval(op);
-    }
-    /**
-     * Eval sends all the recorded and stored operations in the vector of
-     * operations into the gpu as a submit job with a barrier.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> eval(std::shared_ptr<Algorithm> algorithm,
-                                   TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->eval(op);
     }
 
@@ -148,6 +113,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync();
+
     /**
      * Clears currnet operations to record provided one in the vector of
      * operations into the gpu as a submit job without a barrier. EvalAwait()
@@ -157,39 +123,23 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync(std::shared_ptr<OpBase> op);
+
     /**
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
      *
-     * @param tensors Vector of tensors to use for the operation
+     * @param param Template parameter that is used to initialise the operation.
      * @param TArgs Template parameters that are used to initialise operation
      * which allows for extensible configurations on initialisation.
      * @return shared_ptr<Sequence> of the Sequence class itself
      */
     template<typename T, typename... TArgs>
     std::shared_ptr<Sequence> evalAsync(
-      std::vector<std::shared_ptr<Tensor>> tensors,
+      typename T::ConstructorParameterType param,
       TArgs&&... params)
     {
-        std::shared_ptr<T> op{ new T(tensors, std::forward<TArgs>(params)...) };
-        return this->evalAsync(op);
-    }
-    /**
-     * Eval sends all the recorded and stored operations in the vector of
-     * operations into the gpu as a submit job with a barrier.
-     *
-     * @param algorithm Algorithm to use for the record often used for OpAlgo
-     * operations
-     * @param TArgs Template parameters that are used to initialise operation
-     * which allows for extensible configurations on initialisation.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    template<typename T, typename... TArgs>
-    std::shared_ptr<Sequence> evalAsync(std::shared_ptr<Algorithm> algorithm,
-                                        TArgs&&... params)
-    {
-        std::shared_ptr<T> op{ new T(algorithm,
-                                     std::forward<TArgs>(params)...) };
+        static_assert(std::is_base_of<OpBase, T>::value, "T must derive from OpBase");
+        std::shared_ptr<T> op{ new T(param, std::forward<TArgs>(params)...) };
         return this->evalAsync(op);
     }
 

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -378,4 +378,11 @@ class TensorT : public Tensor
     TensorDataTypes dataType();
 };
 
+struct TensorRegion {
+  std::shared_ptr<Tensor> tensor;
+  uint32_t srcIndex;
+  uint32_t dstIndex;
+  uint32_t elemCount;
+};
+
 } // End namespace kp

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -99,8 +99,9 @@ class Tensor
 
     /**
      * Records a copy from the memory of the tensor provided to the current
-     * thensor. This is intended to pass memory into a processing, to perform
+     * tensor. This is intended to pass memory into a processing, to perform
      * a staging buffer transfer, or to gather output (between others).
+     * Copies the entire tensor.
      *
      * @param commandBuffer Vulkan Command Buffer to record the commands into
      * @param copyFromTensor Tensor to copy the data from
@@ -109,22 +110,55 @@ class Tensor
                         std::shared_ptr<Tensor> copyFromTensor);
 
     /**
+     * Records a copy from the memory of the tensor provided to the current
+     * tensor. This is intended to pass memory into a processing, to perform
+     * a staging buffer transfer, or to gather output (between others).
+     *
+     * @param commandBuffer Vulkan Command Buffer to record the commands into
+     * @param copyFromTensor Tensor to copy the data from
+     * @param copyRegion The buffer region to copy
+     */
+    void recordCopyFrom(const vk::CommandBuffer& commandBuffer,
+                        std::shared_ptr<Tensor> copyFromTensor,
+                        const vk::BufferCopy copyRegion);
+
+    /**
      * Records a copy from the internal staging memory to the device memory
      * using an optional barrier to wait for the operation. This function would
-     * only be relevant for kp::Tensors of type eDevice.
+     * only be relevant for kp::Tensors of type eDevice. Copies the entire tensor.
      *
      * @param commandBuffer Vulkan Command Buffer to record the commands into
      */
     void recordCopyFromStagingToDevice(const vk::CommandBuffer& commandBuffer);
 
     /**
+     * Records a copy from the internal staging memory to the device memory
+     * using an optional barrier to wait for the operation. This function would
+     * only be relevant for kp::Tensors of type eDevice.
+     *
+     * @param commandBuffer Vulkan Command Buffer to record the commands into
+     * @param copyRegion The buffer region to copy
+     */
+    void recordCopyFromStagingToDevice(const vk::CommandBuffer& commandBuffer, const vk::BufferCopy copyRegion);
+
+    /**
+     * Records a copy from the internal device memory to the staging memory
+     * using an optional barrier to wait for the operation. This function would
+     * only be relevant for kp::Tensors of type eDevice. Copies the entire tensor.
+     *
+     * @param commandBuffer Vulkan Command Buffer to record the commands into
+     */
+    void recordCopyFromDeviceToStaging(const vk::CommandBuffer& commandBuffer);
+    
+    /**
      * Records a copy from the internal device memory to the staging memory
      * using an optional barrier to wait for the operation. This function would
      * only be relevant for kp::Tensors of type eDevice.
      *
      * @param commandBuffer Vulkan Command Buffer to record the commands into
+     * @param copyRegion The buffer region to copy
      */
-    void recordCopyFromDeviceToStaging(const vk::CommandBuffer& commandBuffer);
+    void recordCopyFromDeviceToStaging(const vk::CommandBuffer& commandBuffer, const vk::BufferCopy copyRegion);
 
     /**
      * Records the buffer memory barrier into the primary buffer and command

--- a/src/include/kompute/operations/OpAlgoDispatch.hpp
+++ b/src/include/kompute/operations/OpAlgoDispatch.hpp
@@ -17,6 +17,8 @@ namespace kp {
 class OpAlgoDispatch : public OpBase
 {
   public:
+    using ConstructorParameterType = std::shared_ptr<kp::Algorithm>;
+
     /**
      * Constructor that stores the algorithm to use as well as the relevant
      * push constants to override when recording.

--- a/src/include/kompute/operations/OpBase.hpp
+++ b/src/include/kompute/operations/OpBase.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpBase
 {
   public:
+    using ConstructorParameterType = void;
+
     /**
      * Default destructor for OpBase class. This OpBase destructor class should
      * always be called to destroy and free owned resources unless it is

--- a/src/include/kompute/operations/OpMemoryBarrier.hpp
+++ b/src/include/kompute/operations/OpMemoryBarrier.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpMemoryBarrier : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+
     /**
      * Constructor that stores tensors as well as memory barrier parameters to
      * be used to create a pipeline barrier on the respective primary or staging

--- a/src/include/kompute/operations/OpMult.hpp
+++ b/src/include/kompute/operations/OpMult.hpp
@@ -21,6 +21,8 @@ namespace kp {
 class OpMult : public OpAlgoDispatch
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the bare minimum
      * requirements for the operations to be able to create and manage their

--- a/src/include/kompute/operations/OpTensorCopy.hpp
+++ b/src/include/kompute/operations/OpTensorCopy.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpTensorCopy : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation.

--- a/src/include/kompute/operations/OpTensorCopyRegion.hpp
+++ b/src/include/kompute/operations/OpTensorCopyRegion.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "kompute/Core.hpp"
+
+#include "kompute/Tensor.hpp"
+
+#include "kompute/operations/OpBase.hpp"
+
+namespace kp {
+
+struct TensorCopyRegions {
+  std::shared_ptr<Tensor> srcTensor;
+  std::vector<TensorRegion> dstRegions;
+};
+
+/**
+ * Operation that copies the data from the first tensor to the rest of the
+ * tensors provided, using a record command for all the vectors. This operation
+ * does not own/manage the memory of the tensors passed to it. The operation
+ * must only receive tensors of type
+ */
+class OpTensorCopyRegion : public OpBase
+{
+  public:
+    using ConstructorParameterType = TensorCopyRegions;
+
+    /**
+     * Default constructor with parameters that provides the core vulkan
+     * resources and the tensors that will be used in the operation.
+     *
+     * @param tensors Tensors that will be used to create in operation.
+     */
+    OpTensorCopyRegion(const TensorCopyRegions regions);
+
+    /**
+     * Default destructor. This class does not manage memory so it won't be
+     * expecting the parent to perform a release.
+     */
+    ~OpTensorCopyRegion() override;
+
+    /**
+     * Records the copy commands from the first tensor into all the other
+     * tensors provided. Also optionally records a barrier.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    void record(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * Does not perform any preEval commands.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void preEval(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * Does not perform any preEval commands.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void postEval(const vk::CommandBuffer& commandBuffer) override;
+
+  private:
+    // -------------- ALWAYS OWNED RESOURCES
+    TensorCopyRegions mRegions;
+};
+
+} // End namespace kp

--- a/src/include/kompute/operations/OpTensorSyncDevice.hpp
+++ b/src/include/kompute/operations/OpTensorSyncDevice.hpp
@@ -18,6 +18,8 @@ namespace kp {
 class OpTensorSyncDevice : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation. The tensos

--- a/src/include/kompute/operations/OpTensorSyncLocal.hpp
+++ b/src/include/kompute/operations/OpTensorSyncLocal.hpp
@@ -20,6 +20,8 @@ namespace kp {
 class OpTensorSyncLocal : public OpBase
 {
   public:
+    using ConstructorParameterType = std::vector<std::shared_ptr<Tensor>>;
+    
     /**
      * Default constructor with parameters that provides the core vulkan
      * resources and the tensors that will be used in the operation. The tensors

--- a/src/include/kompute/operations/OpTensorSyncRegionDevice.hpp
+++ b/src/include/kompute/operations/OpTensorSyncRegionDevice.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "kompute/Core.hpp"
+#include "kompute/Tensor.hpp"
+#include "kompute/operations/OpBase.hpp"
+
+namespace kp {
+
+/**
+ * Operation that syncs tensor's device by mapping local data into the device
+ * memory. For TensorTypes::eDevice it will use a record operation for the
+ * memory to be syncd into GPU memory which means that the operation will be
+ * done in sync with GPU commands. For TensorTypes::eHost it will only map the
+ * data into host memory which will happen during preEval before the recorded
+ * commands are dispatched.
+ */
+class OpTensorSyncRegionDevice : public OpBase
+{
+  public:
+    using ConstructorParameterType = std::vector<TensorRegion>;
+
+    /**
+     * Default constructor with parameters that provides the core vulkan
+     * resources and the tensors that will be used in the operation. The tensors
+     * provided cannot be of type TensorTypes::eStorage.
+     * For each tensor a region to copy is specified.
+     *
+     * @param tensors Tensors that will be used to create in operation.
+     * @param copyRegions The regions to copy.
+     */
+    OpTensorSyncRegionDevice(const std::vector<TensorRegion>& regions);
+
+    /**
+     * Default destructor. This class does not manage memory so it won't be
+     * expecting the parent to perform a release.
+     */
+    ~OpTensorSyncRegionDevice() override;
+
+    /**
+     * For device tensors, it records the copy command for the tensor to copy
+     * the data from its staging to device memory.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    void record(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * Does not perform any preEval commands.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void preEval(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * Does not perform any postEval commands.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void postEval(const vk::CommandBuffer& commandBuffer) override;
+
+  private:
+    // -------------- ALWAYS OWNED RESOURCES
+    std::vector<TensorRegion> mRegions;
+};
+
+} // End namespace kp

--- a/src/include/kompute/operations/OpTensorSyncRegionLocal.hpp
+++ b/src/include/kompute/operations/OpTensorSyncRegionLocal.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "kompute/Core.hpp"
+
+#include "kompute/Tensor.hpp"
+
+#include "kompute/operations/OpBase.hpp"
+
+namespace kp {
+
+/**
+ * Operation that syncs tensor's local memory by mapping device data into the
+ * local CPU memory. For TensorTypes::eDevice it will use a record operation
+ * for the memory to be syncd into GPU memory which means that the operation
+ * will be done in sync with GPU commands. For TensorTypes::eHost it will
+ * only map the data into host memory which will happen during preEval before
+ * the recorded commands are dispatched.
+ */
+class OpTensorSyncRegionLocal : public OpBase
+{
+  public:
+    using ConstructorParameterType = std::vector<TensorRegion>;
+    
+    /**
+     * Default constructor with parameters that provides the core vulkan
+     * resources and the tensors that will be used in the operation. The tensors
+     * provided cannot be of type TensorTypes::eStorage.
+     *
+     * @param tensors Tensors that will be used to create in operation.
+     */
+    OpTensorSyncRegionLocal(const std::vector<TensorRegion>& tensors);
+
+    /**
+     * Default destructor. This class does not manage memory so it won't be
+     * expecting the parent to perform a release.
+     */
+    ~OpTensorSyncRegionLocal() override;
+
+    /**
+     * For device tensors, it records the copy command for the tensor to copy
+     * the data from its device to staging memory.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    void record(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * Does not perform any preEval commands.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void preEval(const vk::CommandBuffer& commandBuffer) override;
+
+    /**
+     * For host tensors it performs the map command from the host memory into
+     * local memory.
+     *
+     * @param commandBuffer The command buffer to record the command into.
+     */
+    virtual void postEval(const vk::CommandBuffer& commandBuffer) override;
+
+  private:
+    // -------------- ALWAYS OWNED RESOURCES
+    std::vector<TensorRegion> mRegions;
+};
+
+} // End namespace kp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(kompute_tests TestAsyncOperations.cpp
     TestMultipleAlgoExecutions.cpp
     TestOpShadersFromStringAndFile.cpp
     TestOpTensorCopy.cpp
+    TestOpTensorSync.cpp
     TestOpTensorCreate.cpp
     TestPushConstant.cpp
     TestSequence.cpp

--- a/test/TestOpTensorSync.cpp
+++ b/test/TestOpTensorSync.cpp
@@ -53,3 +53,51 @@ TEST(TestOpTensorSync, SyncToDeviceMemoryMultiTensor)
     EXPECT_EQ(tensorB->vector(), testVec);
     EXPECT_EQ(tensorC->vector(), testVec);
 }
+
+TEST(TestOpTensorSync, SyncToDeviceMemoryCopyRegion)
+{
+    kp::Manager mgr;
+
+    std::vector<float> testVecPreA{ 1, 2, 3, 4 };
+    std::vector<float> testVecPostA{ 1, 1, 1, 4 };
+    std::vector<float> testVecPostB{ 0, 0, 0, 1 };
+
+    std::shared_ptr<kp::TensorT<float>> tensorA = mgr.tensor({ 0, 0, 0, 0 });
+    std::shared_ptr<kp::TensorT<float>> tensorB = mgr.tensor({ 0, 0, 0, 0 });
+
+    EXPECT_TRUE(tensorA->isInit());
+    EXPECT_TRUE(tensorB->isInit());
+
+    mgr.sequence()->eval<kp::OpTensorSyncDevice>({ tensorA, tensorB });
+
+    // tensorA local: { 0, 0, 0, 0 }  |  tensorA device: { 0, 0, 0, 0 }
+    // tensorB local: { 0, 0, 0, 0 }  |  tensorB device: { 0, 0, 0, 0 }
+
+    tensorA->setData(testVecPreA);
+    
+    // tensorA local: { 1, 2, 3, 4 }  |  tensorA device: { 0, 0, 0, 0 }
+    // tensorB local: { 0, 0, 0, 0 }  |  tensorB device: { 0, 0, 0, 0 }
+
+    // Copy from tensorA local index 0 to tensorA device index 1 (1 element)
+    mgr.sequence()->eval<kp::OpTensorSyncRegionDevice>({{ tensorA, 0, 1, 1 }});
+    
+    // tensorA local: { 1, 2, 3, 4 }  |  tensorA device: { 0, 1, 0, 0 }
+    // tensorB local: { 0, 0, 0, 0 }  |  tensorB device: { 0, 0, 0, 0 }
+
+    // Copy from tensorA device index 1 to tensorA device index 2 (1 element)
+    // Copy from tensorA device index 1 to tensorB device index 2 (1 element)
+    mgr.sequence()->eval<kp::OpTensorCopyRegion>({ tensorA, {{ tensorA, 1, 2, 1 }, { tensorB, 1, 2, 1 }}});
+    
+    // tensorA local: { 1, 2, 3, 4 }  |  tensorA device: { 0, 1, 1, 0 }
+    // tensorB local: { 0, 0, 0, 0 }  |  tensorB device: { 0, 0, 1, 0 }
+
+    // Copy from tensorA device index 1 to tensorA local index 1 (2 elements)
+    // Copy from tensorB device index 2 to tensorB local index 3 (1 element)
+    mgr.sequence()->eval<kp::OpTensorSyncRegionLocal>({{ tensorA, 1, 1, 2 }, { tensorB, 2, 3, 1 }});
+    
+    // tensorA local: { 1, 1, 1, 4 }  |  tensorA device: { 0, 1, 1, 0 }
+    // tensorB local: { 0, 0, 1, 0 }  |  tensorB device: { 0, 0, 1, 0 }
+
+    EXPECT_EQ(tensorA->vector(), testVecPostA);
+    EXPECT_EQ(tensorB->vector(), testVecPostB);
+}


### PR DESCRIPTION
This PR adds the operations `OpTensorCopyRegion`, `OpTensorSyncRegionDevice` and `OpTensorSyncRegionLocal`.
They behave similar to their non Region counterparts, but support copying only regions of a tensor.

I have also added a Test, illustrating their use.
Each tensor is accompanied by a region (src, dst, size) to be copied.
For the two `sync` operations this relates to each given tensor itself.
For the `copy` operation this relates to the source tensor.

It is based on PR #329 and PR #331 so their commits are currently included as well.
If they get merged I can rebase this PR. 
