### PR TITLE
Fix cmake installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,9 @@ compile_commands.json
 .clangd/
 .cache/
 
+# CLion/IDEA files
+.idea/
+
 # Project files
 bin/
 external/boost/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,14 @@ configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/komputeConfig.cmake.in
     "${PROJECT_BINARY_DIR}/kompute/komputeConfig.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kompute)
 
+# Generated komputeConfigVersion.cmake that is required in the following install command
+# This will fix issue #324
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/kompute/komputeConfigVersion.cmake"
+    VERSION ${CMAKE_PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion # Other possible values: SameMajorVersion, SameMinorVersion, ExactVersion
+)
+
 install(FILES ${PROJECT_BINARY_DIR}/kompute/komputeConfig.cmake
     ${PROJECT_BINARY_DIR}/kompute/komputeConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kompute)
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -41,4 +41,7 @@ target_sources(kp_logger PRIVATE
     kompute/logger/Logger.hpp
 )
 
-install(DIRECTORY logger DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# This installation requires non-existing dir logger,
+# but previous installation at line 30 has already installed kompute/logger
+# This will cause an error during installation
+# install(DIRECTORY logger DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Issue https://github.com/KomputeProject/kompute/issues/324 mentioned that installation fails on many platforms because
komputeConfigVersion.cmake is missing. I tried and found out that this issue happens on may platforms, (for example, on Windows11 with msvc and clang16, and on archlinux with gcc13 and clang16).

So I add some lines to generate it, and I believe this will fix https://github.com/KomputeProject/kompute/issues/324 .

Header installation is also fixed. An extra install command in src/include/CMakeLists.txt is removed because it requires non-existing directory src/include/logger, but logger headers are in src/include/kompute/logger. This line is redundant because logger headers are already installed with line 30.
```cmake
install(DIRECTORY kompute DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
```