### PR TITLE
Fix example build

### DIFF
--- a/.github/workflows/cpp_examples.yml
+++ b/.github/workflows/cpp_examples.yml
@@ -27,7 +27,7 @@ jobs:
         build-type: Debug
         run-test: false
         ctest-options: -V
-        configure-options: -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON KOMPUTE_OPT_FROM_SOURCE=ON
+        configure-options: -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON -DKOMPUTE_OPT_FROM_SOURCE=ON
         build-options: --parallel # Given we don't build too many resources we can leverage parallel
     - name: Run tests
       run: ./examples/array_multiplication/build/src/kompute_array_mult
@@ -52,7 +52,7 @@ jobs:
         build-type: Debug
         run-test: false
         ctest-options: -V
-        configure-options: -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON KOMPUTE_OPT_FROM_SOURCE=ON
+        configure-options: -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=ON -DKOMPUTE_OPT_FROM_SOURCE=ON
         build-options: --parallel # Given we don't build too many resources we can leverage parallel
     - name: Run tests
       run: ./examples/logistic_regression/build/src/kompute_logistic_regression

--- a/cmake/set_package_info.cmake
+++ b/cmake/set_package_info.cmake
@@ -15,12 +15,12 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GPGPU framework built on Vulkan.")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://kompute.cc/")
 
 # The license file used by GUI installers
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 # The readme file used by GUI installers
-set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
 
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}\\\\${PROJECT_VERSION}")
-# set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/docs/images/kompute.jpg")
+# set(CPACK_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/docs/images/kompute.jpg")
 
 # Other common variables, in most cases they are not used,
 # otherwise their default values are ok.
@@ -53,7 +53,7 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}\\\\${PROJECT_VERSION}")
 
 # Setup detailed package info for any cpack generator.
 # Each file correspond to a cpack generator
-file(GLOB config_files "${CMAKE_SOURCE_DIR}/cmake/cpack-configs/*.cmake")
+file(GLOB config_files "${PROJECT_SOURCE_DIR}/cmake/cpack-configs/*.cmake")
 foreach (config_file ${config_files})
     include(${config_file})
 endforeach ()


### PR DESCRIPTION
I see 2 example tests in "C++ Test" action failed after merging my PR.

It was caused by `CMAKE_SOURCE_DIR` in file `cmake/set_package_info.cmake` to access readme and license files. It seems ok beacuse they works almost the same as `PROJECT_SOURCE_DIR`, but in example builds `CMAKE_SOURCE_DIR` points to `examples/logistic_regression` , however license and readme files are not located here.

So I replaced `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` to fix this.

The `cpp_example` gh action is also changed. 
Before this, cmd line parameter `KOMPUTE_OPT_FROM_SOURCE=ON` doesn't start with a `-D` prefix, so it will be ignored without any warnings and the value of `KOMPUTE_OPT_FROM_SOURCE` is still false. 
As a result, example builds will still access kompute **from the remote master branch** instead of the parent directory. I have to fix this, otherwise gh actions will always fail.