### PR TITLE
Manager: fix debug layers on Android

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -179,6 +179,13 @@ Manager::createInstance()
           applicationExtensions.data();
     }
 
+#if VK_USE_PLATFORM_ANDROID_KHR
+    vk::DynamicLoader dl;
+    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
+      dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
+#endif // VK_USE_PLATFORM_ANDROID_KHR
+
 #ifndef KOMPUTE_DISABLE_VK_DEBUG_LAYERS
     KP_LOG_DEBUG("Kompute Manager adding debug validation layers");
     // We'll identify the layers that are supported
@@ -232,13 +239,6 @@ Manager::createInstance()
                     "layer names");
     }
 #endif
-
-#if VK_USE_PLATFORM_ANDROID_KHR
-    vk::DynamicLoader dl;
-    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
-      dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
-    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
-#endif // VK_USE_PLATFORM_ANDROID_KHR
 
     this->mInstance = std::make_shared<vk::Instance>();
     vk::createInstance(

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -261,7 +261,7 @@ Manager::createInstance()
           (PFN_vkDebugReportCallbackEXT)debugMessageCallback;
         debugCreateInfo.flags = debugFlags;
 
-        this->mDebugDispatcher.init(*this->mInstance, &vkGetInstanceProcAddr);
+        this->mDebugDispatcher.init(*this->mInstance, vkGetInstanceProcAddr);
         this->mDebugReportCallback =
           this->mInstance->createDebugReportCallbackEXT(
             debugCreateInfo, nullptr, this->mDebugDispatcher);


### PR DESCRIPTION
I haven't tested this on Android, but on a fork that always uses the dynamic symbol lookup, I ran into this compilation error:
```
/home/admin/src_clones/gpt4all/gpt4all-backend/llama.cpp-mainline/kompute/src/Manager.cpp:273:36: error: no matching function for call to ‘vk::DispatchLoaderDynamic::init(std::__shared_ptr_access<vk::Instance, __gnu_cxx::_S_atomic, false, false>::element_type&, void (* (**)(VkInstance, const char*))())’
  273 |         this->mDebugDispatcher.init(*this->mInstance, &vkGetInstanceProcAddr);
<snip>
/home/admin/src_clones/gpt4all/gpt4all-backend/build/_deps/vulkan_header-src/include/vulkan/vulkan.hpp:13180:42: note:   no known conversion for argument 2 from ‘void (* (**)(VkInstance, const char*))()’ {aka ‘void (* (**)(VkInstance_T*, const char*))()’} to ‘PFN_vkGetInstanceProcAddr’ {aka ‘void (* (*)(VkInstance_T*, const char*))()’}
```

It should be possible to reproduce if you build it like this:
```
$ cmake -B build -DKOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS=OFF -DKOMPUTE_OPT_ANDROID_BUILD=ON
$ make -C build
```