### PR TITLE
Readded missing codecov cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,14 +256,6 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
 endif()
 
-if(KOMPUTE_OPT_CODE_COVERAGE)
-    if(NOT UNIX)
-        message(FATAL_ERROR "KOMPUTE_OPT_CODE_COVERAGE can only be enabled in unix based systems due to limitation on gcov.")
-    endif()
-
-    include(cmake/code_coverage.cmake)
-endif()
-
 # If glslang is cloned, then SPIRV/GlslangToSpv.h will be used instead of glslang/SPIRV/GlslangToSpv.h
 # As after installation, SPIRV/ header files will be found in glslang/SPIRV/ , more info in #193
 if(KOMPUTE_OPT_REPO_SUBMODULE_BUILD)
@@ -281,6 +273,14 @@ add_subdirectory(src)
 if(KOMPUTE_OPT_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
+endif()
+
+if(KOMPUTE_OPT_CODE_COVERAGE)
+    if(NOT UNIX)
+        message(FATAL_ERROR "KOMPUTE_OPT_CODE_COVERAGE can only be enabled in unix based systems due to limitation on gcov.")
+    endif()
+
+    include(cmake/code_coverage.cmake)
 endif()
 
 if(KOMPUTE_OPT_BUILD_DOCS)

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,10 @@ mk_build_kompute:
 mk_build_tests:
 	cmake --build build/. --target kompute_tests --parallel
 
-mk_run_docs: mk_build_docs
-	(cd build/docs/sphinx && python2.7 -m SimpleHTTPServer)
+mk_run_docs: mk_build_docs mk_run_docs_only
+
+mk_run_docs_only:
+	(cd build/docs/sphinx && python -m http.server)
 
 # An alternative would be: ctest -vv --test-dir build/.
 # But this is not possible since we need to filter specific tests, not complete executables, which is not possible with ctest.

--- a/docs/overview/ci-tests.rst
+++ b/docs/overview/ci-tests.rst
@@ -70,7 +70,9 @@ In order to build the documentation you will need the following dependencies:
 Once this installed:
 
 * You can build the documentation using the `gendocsall` cmake target
-* You can serve the documentation locally using the `mk_run_docs` command in the Makefile
+    * This can be done with `make clean_cmake mk_cmake mk_build_docs`
+* You can serve the documentation locally using the `mk_run_docs_only` command in the Makefile
+>>>>>>> Stashed changes
 
 Performing Release
 ~~~~~~~~~~~~

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,5 +7,14 @@ quom==1.2.0
 Sphinx==3.2.1
 sphinx_material==0.0.30
 breathe==4.20.0
+
+# Dependencies for m2r2
 m2r2==0.2.5
-git+git://github.com/pybind/pybind11_mkdoc.git@master
+docutils<0.18
+mistune<2
+
+# NEeded for backward compat of Sphynx
+Jinja2<3.1
+
+# Needed for the pybind docstrings
+pybind11_mkdoc @ git+https://github.com/pybind/pybind11_mkdoc@master

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,3 +39,5 @@ if(WIN32 AND BUILD_SHARED_LIBS) # Install dlls in the same directory as the exec
     add_custom_command(TARGET kompute_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:spdlog> $<TARGET_FILE_DIR:kompute_tests>)
     add_custom_command(TARGET kompute_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:kp_logger> $<TARGET_FILE_DIR:kompute_tests>)
 endif()
+
+


### PR DESCRIPTION
The codecov cmake targets were accidentally removed as part of #287 but readding in this PR with further fixes including pinned dependencies.