### PR TITLE
Fix example CMake code for generating headers from GLSL code

### DIFF
--- a/docs/overview/shaders-to-headers.rst
+++ b/docs/overview/shaders-to-headers.rst
@@ -87,6 +87,7 @@ If you are using CMake as build system you can use CMake to directly convert you
                                  GIT_TAG 1344ece4ac278f9b3be3b4555ffaace7a032b91f) # The commit hash for a dev version before v0.9.0. Replace with the latest from: https://github.com/KomputeProject/kompute/releases
     FetchContent_MakeAvailable(kompute)
     include_directories(${kompute_SOURCE_DIR}/src/include)
+    include_directories(${kompute_BINARY_DIR}/src/shaders/glsl)
 
     # Add to the list, so CMake can later find the code to compile shaders to header files
     list(APPEND CMAKE_PREFIX_PATH "${kompute_SOURCE_DIR}/cmake")


### PR DESCRIPTION
We need to include ${kompute_BINARY_DIR}/src/shaders/glsl as this is where ShaderOpMult.hpp is built (included from
include/kompute/operations/OpMult.hpp)