### PR TITLE
expose `vulkan_compile_shader` with CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,13 @@ if(KOMPUTE_OPT_INSTALL)
         FILE komputeTargets.cmake
         NAMESPACE kompute::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kompute)
+
+    # Copy CMake files needed to `vulkan_compile_shader`
+    install(FILES
+        cmake/vulkan_shader_compiler.cmake
+        cmake/bin_file_to_header.cmake
+        cmake/bin2h.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kompute)
 endif()
 
 

--- a/cmake/komputeConfig.cmake.in
+++ b/cmake/komputeConfig.cmake.in
@@ -5,4 +5,7 @@ find_dependency(Vulkan REQUIRED)
 
 include(${CMAKE_CURRENT_LIST_DIR}/komputeTargets.cmake)
 
+# Expose `vulkan_compile_shader`
+include(${CMAKE_CURRENT_LIST_DIR}/vulkan_shader_compiler.cmake)
+
 check_required_components(kompute)


### PR DESCRIPTION
https://github.com/KomputeProject/kompute/issues/381

This would enable CMake users to use `vulkan_compile_shader` through the CMake install route. Important step for packaging Kompute for VCPKG, which I'm working on. 