### PR TITLE
fix fmt include in Manager

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "kompute/Manager.hpp"
-#include "fmt/format.h"
 #include "kompute/logger/Logger.hpp"
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <iterator>
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 namespace kp {
 

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <set>
-#include <unordered_map>
-
 #include "kompute/Core.hpp"
-
 #include "kompute/Sequence.hpp"
 #include "logger/Logger.hpp"
 


### PR DESCRIPTION
When building with `-DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF` using `fmt` from vcpkg, I was getting build errors in `Manager.cpp` saying `error: no member named 'join' in namespace 'fmt'`. `join` is defined in `<fmt/ranges.h>` which wasn't included. I'm not sure how kompute can build with the built in fmt. 

Another trivial thing was that the `<set>` and `<unordered_map>` headers were not used in `Manager.hpp` so I moved them to `Manager.cpp`.