### PR TITLE
Fix barrier in flag TestMultipleAlgoExecutions::SingleSequenceRecord

### DIFF
--- a/test/TestMultipleAlgoExecutions.cpp
+++ b/test/TestMultipleAlgoExecutions.cpp
@@ -93,10 +93,10 @@ TEST(TestMultipleAlgoExecutions, SingleSequenceRecord)
     std::vector<uint32_t> spirv = compileSource(shader);
 
     {
-        // A sharedMemoryBarrier is required as the shader is not thread-safe:w
+        // A sharedMemoryBarrier is required as the shader is not thread-safe
         std::shared_ptr<kp::OpMemoryBarrier> shaderBarrier{
             new kp::OpMemoryBarrier({ tensorA },
-                                    vk::AccessFlagBits::eTransferRead,
+                                    vk::AccessFlagBits::eShaderRead,
                                     vk::AccessFlagBits::eShaderWrite,
                                     vk::PipelineStageFlagBits::eComputeShader,
                                     vk::PipelineStageFlagBits::eComputeShader)


### PR DESCRIPTION
Fixes this validation error:

VUID-vkCmdPipelineBarrier-pBufferMemoryBarriers-02817(ERROR / SPEC): msgNum: -541109872 - Validation Error: [ VUID-vkCmdPipelineBarrier-pBufferMemoryBarriers-02817 ] Object 0: handle = 0x55eb3e5027d0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xdfbf5190 | vkCmdPipelineBarrier(): pBufferMemoryBarriers[0].srcAccessMask (VK_ACCESS_TRANSFER_READ_BIT) is not supported by stage mask (VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT). The Vulkan spec states: For any element of pBufferMemoryBarriers, if its srcQueueFamilyIndex and dstQueueFamilyIndex members are equal, or if its srcQueueFamilyIndex is the queue family index that was used to create the command pool that commandBuffer was allocated from, then its srcAccessMask member must only contain access flags that are supported by one or more of the pipeline stages in srcStageMask, as specified in the table of supported access types (https://vulkan.lunarg.com/doc/view/1.3.280.0/linux/1.3-extensions/vkspec.html#VUID-vkCmdPipelineBarrier-pBufferMemoryBarriers-02817)