### PR TITLE
Use a unique name for CMake build-time-make-directory

### DIFF
--- a/cmake/vulkan_shader_compiler.cmake
+++ b/cmake/vulkan_shader_compiler.cmake
@@ -34,7 +34,8 @@ function(vulkan_compile_shader)
      ## The directory may not be created so we need to ensure its present 
      get_filename_component(SHADER_COMPILE_SPV_PATH ${SHADER_COMPILE_SPV_FILE_FULL} DIRECTORY)
      if(NOT EXISTS ${SHADER_COMPILE_SPV_PATH})
-         add_custom_target(build-time-make-directory ALL
+             get_filename_component(SHADER_COMPILE_SPV_FILENAME ${SHADER_COMPILE_SPV_FILE_FULL} FILENAME)
+             add_custom_target(build-time-make-directory-${SHADER_COMPILE_SPV_FILENAME} ALL
              COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_COMPILE_SPV_PATH})
      endif()
      ## Requires custom command function as this is the only way to call 

--- a/cmake/vulkan_shader_compiler.cmake
+++ b/cmake/vulkan_shader_compiler.cmake
@@ -34,7 +34,7 @@ function(vulkan_compile_shader)
      ## The directory may not be created so we need to ensure its present 
      get_filename_component(SHADER_COMPILE_SPV_PATH ${SHADER_COMPILE_SPV_FILE_FULL} DIRECTORY)
      if(NOT EXISTS ${SHADER_COMPILE_SPV_PATH})
-             get_filename_component(SHADER_COMPILE_SPV_FILENAME ${SHADER_COMPILE_SPV_FILE_FULL} FILENAME)
+             get_filename_component(SHADER_COMPILE_SPV_FILENAME ${SHADER_COMPILE_SPV_FILE_FULL} NAME)
              add_custom_target(build-time-make-directory-${SHADER_COMPILE_SPV_FILENAME} ALL
              COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_COMPILE_SPV_PATH})
      endif()


### PR DESCRIPTION
If CMake calls vulkan_compile_shader multiple times and the shader directory does not exist in the build directory then add_custom_target will be called multiple times with a target name of build-time-make-directory which is not allowed.

Adding the filename of the input file to target name allows this to work and fixes the build.