### PR TITLE
Add support for DeviceAndHost memory

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -442,6 +442,7 @@ Image::getPrimaryImageUsageFlags()
     switch (this->mMemoryType) {
         case MemoryTypes::eDevice:
         case MemoryTypes::eHost:
+        case MemoryTypes::eDeviceAndHost:
             return vk::ImageUsageFlagBits::eStorage |
                    vk::ImageUsageFlagBits::eTransferSrc |
                    vk::ImageUsageFlagBits::eTransferDst;

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -157,7 +157,8 @@ Memory::mapRawData()
 
     std::shared_ptr<vk::DeviceMemory> hostVisibleMemory = nullptr;
 
-    if (this->mMemoryType == MemoryTypes::eHost) {
+    if (this->mMemoryType == MemoryTypes::eHost ||
+        this->mMemoryType == MemoryTypes::eDeviceAndHost) {
         hostVisibleMemory = this->mPrimaryMemory;
     } else if (this->mMemoryType == MemoryTypes::eDevice) {
         hostVisibleMemory = this->mStagingMemory;
@@ -187,7 +188,8 @@ Memory::unmapRawData()
 
     std::shared_ptr<vk::DeviceMemory> hostVisibleMemory = nullptr;
 
-    if (this->mMemoryType == MemoryTypes::eHost) {
+    if (this->mMemoryType == MemoryTypes::eHost ||
+        this->mMemoryType == MemoryTypes::eDeviceAndHost) {
         hostVisibleMemory = this->mPrimaryMemory;
     } else if (this->mMemoryType == MemoryTypes::eDevice) {
         hostVisibleMemory = this->mStagingMemory;
@@ -226,6 +228,10 @@ Memory::getPrimaryMemoryPropertyFlags()
             return vk::MemoryPropertyFlagBits::eHostVisible |
                    vk::MemoryPropertyFlagBits::eHostCoherent;
             break;
+        case MemoryTypes::eDeviceAndHost:
+            return vk::MemoryPropertyFlagBits::eDeviceLocal |
+                   vk::MemoryPropertyFlagBits::eHostVisible |
+                   vk::MemoryPropertyFlagBits::eHostCoherent;
         case MemoryTypes::eStorage:
             return vk::MemoryPropertyFlagBits::eDeviceLocal;
             break;

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -282,12 +282,14 @@ Tensor::constructDescriptorSet(vk::DescriptorSet descriptorSet,
 
     return writeDesciptorSet;
 }
+
 vk::BufferUsageFlags
 Tensor::getPrimaryBufferUsageFlags()
 {
     switch (this->mMemoryType) {
         case MemoryTypes::eDevice:
         case MemoryTypes::eHost:
+        case MemoryTypes::eDeviceAndHost:
             return vk::BufferUsageFlagBits::eStorageBuffer |
                    vk::BufferUsageFlagBits::eTransferSrc |
                    vk::BufferUsageFlagBits::eTransferDst;

--- a/src/include/kompute/Image.hpp
+++ b/src/include/kompute/Image.hpp
@@ -120,7 +120,8 @@ class Image : public Memory
               "Custom data types are not supported for Kompute Images");
         }
 
-        if (memoryType == MemoryTypes::eHost) {
+        if (memoryType == MemoryTypes::eHost ||
+            memoryType == MemoryTypes::eDeviceAndHost) {
             // Host-accessible memory must be linear-tiled.
             tiling = vk::ImageTiling::eLinear;
         } else if (memoryType == MemoryTypes::eDevice ||

--- a/src/include/kompute/Memory.hpp
+++ b/src/include/kompute/Memory.hpp
@@ -29,6 +29,8 @@ class Memory
         eDevice = 0,  ///< Type is device memory, source and destination
         eHost = 1,    ///< Type is host memory, source and destination
         eStorage = 2, ///< Type is Device memory (only)
+        eDeviceAndHost =
+          3, ///< Type is host-visible and host-coherent device memory
     };
 
     enum class DataTypes

--- a/test/TestOpCopyTensor.cpp
+++ b/test/TestOpCopyTensor.cpp
@@ -358,3 +358,27 @@ TEST(TestOpCopyTensor, CopyTensorThroughStorageViaAlgorithmsUninitialisedOutput)
     // Making sure the GPU holds the same vector
     EXPECT_EQ(tensorIn->vector(), tensorOut->vector());
 }
+
+TEST(TestOpTensorCopy, CopyDeviceAndHostToDeviceAndHostTensor)
+{
+    kp::Manager mgr;
+
+    std::vector<float> testVecA{ 1, 2, 3 };
+    std::vector<float> testVecB{ 0, 0, 0 };
+
+    std::shared_ptr<kp::TensorT<float>> tensorA =
+      mgr.tensor(testVecA, kp::Memory::MemoryTypes::eDeviceAndHost);
+    std::shared_ptr<kp::TensorT<float>> tensorB =
+      mgr.tensor(testVecB, kp::Memory::MemoryTypes::eDeviceAndHost);
+
+    EXPECT_TRUE(tensorA->isInit());
+    EXPECT_TRUE(tensorB->isInit());
+
+    mgr.sequence()
+      ->eval<kp::OpSyncDevice>({ tensorA, tensorB })
+      ->eval<kp::OpCopy>({ tensorA, tensorB })
+      ->eval<kp::OpSyncLocal>({ tensorA, tensorB });
+
+    // Making sure the GPU holds the same vector
+    EXPECT_EQ(tensorA->vector(), tensorB->vector());
+}

--- a/test/TestOpImageCreate.cpp
+++ b/test/TestOpImageCreate.cpp
@@ -71,6 +71,21 @@ TEST(TestOpImageCreate, ExceptionOnInvalidTiledImage)
                     1,
                     1,
                     vk::ImageTiling::eOptimal,
+                    kp::Memory::MemoryTypes::eDeviceAndHost);
+    } catch (const std::runtime_error& err) {
+        // check exception
+        ASSERT_TRUE(std::string(err.what())
+                      .find("optimal tiling is only supported for") !=
+                    std::string::npos);
+    }
+
+    try {
+        std::shared_ptr<kp::ImageT<float>> imageA =
+          mgr.image(testVecA,
+                    1,
+                    1,
+                    1,
+                    vk::ImageTiling::eOptimal,
                     kp::Memory::MemoryTypes::eHost);
     } catch (const std::runtime_error& err) {
         // check exception


### PR DESCRIPTION
This is a new memory type with these Vulkan flags set:

        case MemoryTypes::eDeviceAndHost:
            return vk::MemoryPropertyFlagBits::eDeviceLocal |
                   vk::MemoryPropertyFlagBits::eHostVisible |
                   vk::MemoryPropertyFlagBits::eHostCoherent;

It means that a copy between staging and primary memory is not required because the device memory is also host-visible and host-coherent. This type of memory allocation may not be supported on all platforms/devices, but if they do support it it can improve performance by avoiding an unnecessary copy.