### PR TITLE
fix doc typo

### DIFF
--- a/docs/overview/custom-operations.rst
+++ b/docs/overview/custom-operations.rst
@@ -2,7 +2,7 @@
 Extending Kompute with Custom C++ Operations
 =================
 
-Kompute provides an extenisble architecture which allows for the core components to be extended by building custom operations.
+Kompute provides an extensible architecture which allows for the core components to be extended by building custom operations.
 
 Building operations is intuitive however it requires knowing some nuances around the order in which each of the class functions across the operation are called as a sequence is executed.
 


### PR DESCRIPTION
Noticed while reading through the documentation.

I've used spell checkers in the CI for other doc projects. Not adding one here, but I suggest tracking that in an issue if desired