### PR TITLE
Support feature selection for device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ vs_run_tests: vs_build_tests
 #### PYTHONG ####
 
 test_python:
-	python3 -m pytest -s --log-cli-level=DEBUG -v python/test/
+	python3 -m pytest --forked -s --log-cli-level=DEBUG -v python/test/
 
 ####### Run CI Commands #######
 

--- a/python/src/docstrings.hpp
+++ b/python/src/docstrings.hpp
@@ -538,17 +538,11 @@ R"doc(Base constructor and default used which creates the base resources
 including choosing the device 0 by default.)doc";
 
 static const char *__doc_kp_Manager_Manager_2 =
-R"doc(Similar to base constructor but allows for further configuration to
-use when creating the Vulkan resources.
+R"doc(Similar to base constructor but allows selection of the 
+device
 
 Parameter ``physicalDeviceIndex``:
-    The index of the physical device to use
-
-Parameter ``familyQueueIndices``:
-    (Optional) List of queue indices to add for explicit allocation
-
-Parameter ``desiredExtensions``:
-    The desired extensions to load from physicalDevice)doc";
+    The index of the physical device to use)doc";
 
 static const char *__doc_kp_Manager_Manager_3 =
 R"doc(Manager constructor which allows your own vulkan application to
@@ -565,6 +559,23 @@ Parameter ``device``:
 
 Parameter ``physicalDeviceIndex``:
     Index for vulkan physical device used)doc";
+
+static const char *__doc_kp_Manager_Manager_4 =
+R"doc(Similar to second constructor but allows for further configuration to
+control the requested features of the Vulkan device.
+
+Parameter ``device``:
+    The index of the physical device to use
+
+Parameter ``family_queue_indices``:
+    (Optional) List of queue indices to add for explicit allocation
+
+Parameter ``desired_extensions``:
+    The desired extensions to load from physicalDevice
+
+Parameter ``desired_features``:
+    The desired featutures to request from the physicalDevice)doc";
+
 
 static const char *__doc_kp_Manager_algorithm =
 R"doc(Default non-template function that can be used to create algorithm

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -733,7 +733,13 @@ PYBIND11_MODULE(kp, m)
 
             return kp::py::vkPropertiesToDict(properties);
         },
-        "Return a dict containing information about the device");
+        "Return a dict containing information about the device")
+      .def(
+        "get_device_features",
+        [](kp::Manager& self) {
+            return kp::py::vkFeaturesToDict(self.getDeviceFeatures());
+        },
+        "Return a dict containing information about the device features");
 
     auto atexit = py::module_::import("atexit");
     atexit.attr("register")(py::cpp_function([]() {

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -65,6 +65,14 @@ PYBIND11_MODULE(kp, m)
 
     py::module_ np = py::module_::import("numpy");
 
+    py::class_<vk::PhysicalDeviceFeatures>(
+      m, "PhysicalDeviceFeatures")
+      .def(py::init())
+      .def_readwrite("robust_buffer_access", &vk::PhysicalDeviceFeatures::robustBufferAccess)
+      .def_readwrite("shader_float64", &vk::PhysicalDeviceFeatures::shaderFloat64)
+      .def_readwrite("shader_int64", &vk::PhysicalDeviceFeatures::shaderInt64)
+      .def_readwrite("shader_int16", &vk::PhysicalDeviceFeatures::shaderInt16);
+
     py::enum_<kp::Memory::DataTypes>(m, "DataTypes")
       .value("bool",
              kp::Memory::DataTypes::eBool,
@@ -288,12 +296,23 @@ PYBIND11_MODULE(kp, m)
     py::class_<kp::Manager, std::shared_ptr<kp::Manager>>(
       m, "Manager", DOC(kp, Manager))
       .def(py::init(), DOC(kp, Manager, Manager))
-      .def(py::init<uint32_t>(), DOC(kp, Manager, Manager_2))
+      .def(py::init<uint32_t>(),
+           DOC(kp, Manager, Manager_2),
+           py::arg("device") = 0)
       .def(py::init<uint32_t,
                     const std::vector<uint32_t>&,
                     const std::vector<std::string>&>(),
-           DOC(kp, Manager, Manager_2),
+           DOC(kp, Manager, Manager_3),
            py::arg("device") = 0,
+           py::arg("family_queue_indices") = std::vector<uint32_t>(),
+           py::arg("desired_extensions") = std::vector<std::string>())
+      .def(py::init<uint32_t,
+                    const vk::PhysicalDeviceFeatures&,
+                    const std::vector<uint32_t>&,
+                    const std::vector<std::string>&>(),
+           DOC(kp, Manager, Manager_4),
+           py::arg("device") = 0,
+           py::arg("desired_features") = vk::PhysicalDeviceFeatures(),
            py::arg("family_queue_indices") = std::vector<uint32_t>(),
            py::arg("desired_extensions") = std::vector<std::string>())
       .def("destroy", &kp::Manager::destroy, DOC(kp, Manager, destroy))

--- a/python/src/utils.hpp
+++ b/python/src/utils.hpp
@@ -23,9 +23,23 @@ vkPropertiesToDict(const vk::PhysicalDeviceProperties& properties)
         pybind11::make_tuple(properties.limits.maxComputeWorkGroupSize[0],
                              properties.limits.maxComputeWorkGroupSize[1],
                              properties.limits.maxComputeWorkGroupSize[2]),
+      "max_push_constants_size"_a =
+        properties.limits.maxPushConstantsSize,
       "timestamps_supported"_a =
         (bool)properties.limits.timestampComputeAndGraphics);
 
+    return pyDict;
+}
+
+static pybind11::dict
+vkFeaturesToDict(const vk::PhysicalDeviceFeatures& features)
+{
+    pybind11::dict pyDict(
+      "robust_buffer_access"_a = (bool)features.robustBufferAccess,
+      "shader_float64"_a = (bool)features.shaderFloat64,
+      "shader_int64"_a = (bool)features.shaderInt64,
+      "shader_int16"_a = (bool)features.shaderInt16
+    );
     return pyDict;
 }
 }

--- a/python/test/requirements-dev.txt
+++ b/python/test/requirements-dev.txt
@@ -1,4 +1,4 @@
 pyshader==0.7.0
 numpy==1.22.4
 pytest==7.1.2
-
+pytest-xdist==3.6.1

--- a/python/test/requirements-dev.txt
+++ b/python/test/requirements-dev.txt
@@ -1,4 +1,4 @@
 pyshader==0.7.0
 numpy==1.22.4
 pytest==7.1.2
-pytest-xdist==3.6.1
+pytest-forked==1.6.0

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -288,3 +288,8 @@ def test_mgr_utils():
 
     feats = mgr.get_device_features()
     assert "shader_float64" in feats
+
+def test_mgr_request_features():
+    features = kp.PhysicalDeviceFeatures()
+    features.shader_float64 = True
+    mgr = kp.Manager(0, features)

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -279,8 +279,12 @@ def test_mgr_utils():
     props = mgr.get_device_properties()
 
     assert "device_name" in props
+    assert "max_push_constants_size" in props
 
     devices = mgr.list_devices()
 
     assert len(devices) > 0
     assert "device_name" in devices[0]
+
+    feats = mgr.get_device_features()
+    assert "shader_float64" in feats

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -291,5 +291,5 @@ def test_mgr_utils():
 
 def test_mgr_request_features():
     features = kp.PhysicalDeviceFeatures()
-    features.shader_float64 = True
-    mgr = kp.Manager(0, features)
+    #features.shader_float64 = True
+    #mgr = kp.Manager(0, features)

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -291,5 +291,5 @@ def test_mgr_utils():
 
 def test_mgr_request_features():
     features = kp.PhysicalDeviceFeatures()
-    #features.shader_float64 = True
+    features.shader_float64 = True
     #mgr = kp.Manager(0, features)

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -292,4 +292,6 @@ def test_mgr_utils():
 def test_mgr_request_features():
     features = kp.PhysicalDeviceFeatures()
     features.shader_float64 = True
-    #mgr = kp.Manager(0, features)
+
+    kp_log.setLevel(logging.DEBUG)
+    mgr = kp.Manager(0, features)

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -483,6 +483,12 @@ Manager::getDeviceProperties() const
     return this->mPhysicalDevice->getProperties();
 }
 
+vk::PhysicalDeviceFeatures
+Manager::getDeviceFeatures() const
+{
+    return this->mPhysicalDevice->getFeatures();
+}
+
 std::vector<vk::PhysicalDevice>
 Manager::listDevices() const
 {

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -33,9 +33,20 @@ debugMessageCallback(VkDebugReportFlagsEXT /*flags*/,
 }
 #endif
 
+static void setUpLogger() {
+    // Make sure the logger is setup
+#if !KOMPUTE_OPT_LOG_LEVEL_DISABLED
+    logger::setupLogger();
+#endif
+}
+
 Manager::Manager()
-  : Manager(0)
 {
+    this->mManageResources = true;
+    setUpLogger();
+    this->createInstance();
+    this->createDevice(
+      {}, 0, {}, nullptr);
 }
 
 Manager::Manager(uint32_t physicalDeviceIndex,
@@ -43,15 +54,22 @@ Manager::Manager(uint32_t physicalDeviceIndex,
                  const std::vector<std::string>& desiredExtensions)
 {
     this->mManageResources = true;
-
-// Make sure the logger is setup
-#if !KOMPUTE_OPT_LOG_LEVEL_DISABLED
-    logger::setupLogger();
-#endif
-
+    setUpLogger();
     this->createInstance();
     this->createDevice(
-      familyQueueIndices, physicalDeviceIndex, desiredExtensions);
+      familyQueueIndices, physicalDeviceIndex, desiredExtensions, nullptr);
+}
+
+Manager::Manager(uint32_t physicalDeviceIndex,
+                 const vk::PhysicalDeviceFeatures& desiredFeatures,
+                 const std::vector<uint32_t>& familyQueueIndices,
+                 const std::vector<std::string>& desiredExtensions)
+{
+    this->mManageResources = true;
+    setUpLogger();
+    this->createInstance();
+    this->createDevice(
+      familyQueueIndices, physicalDeviceIndex, desiredExtensions, &desiredFeatures);
 }
 
 Manager::Manager(std::shared_ptr<vk::Instance> instance,
@@ -64,10 +82,7 @@ Manager::Manager(std::shared_ptr<vk::Instance> instance,
     this->mPhysicalDevice = physicalDevice;
     this->mDevice = device;
 
-// Make sure the logger is setup
-#if !KOMPUTE_OPT_LOG_LEVEL_DISABLED
-    logger::setupLogger();
-#endif
+    setUpLogger();
 }
 
 Manager::~Manager()
@@ -312,7 +327,8 @@ Manager::clear()
 void
 Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
                       uint32_t physicalDeviceIndex,
-                      const std::vector<std::string>& desiredExtensions)
+                      const std::vector<std::string>& desiredExtensions,
+                      const vk::PhysicalDeviceFeatures* pDesiredFeatures)
 {
 
     KP_LOG_DEBUG("Kompute Manager creating Device");
@@ -436,7 +452,8 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
                                           {},
                                           {},
                                           validExtensions.size(),
-                                          validExtensions.data());
+                                          validExtensions.data(),
+                                          pDesiredFeatures);
 
     this->mDevice = std::make_shared<vk::Device>();
     physicalDevice.createDevice(

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -30,10 +30,29 @@ class Manager
      * @param physicalDeviceIndex The index of the physical device to use
      * @param familyQueueIndices (Optional) List of queue indices to add for
      * explicit allocation
-     * @param desiredExtensions The desired extensions to load from
+     * @param desiredExtensions (Optional) The desired extensions to load from
+     * physicalDevice
+     * @param desiredFeatures (Optional) The desired features to include
+     * in the physical device
+     */
+    Manager(uint32_t physicalDeviceIndex,
+            const std::vector<uint32_t>& familyQueueIndices = {},
+            const std::vector<std::string>& desiredExtensions = {});
+
+    /**
+     * Similar to second constructor but allows for further configuration
+     * for Vulkan device features.
+     *
+     * @param physicalDeviceIndex The index of the physical device to use
+     * @param desiredFeatures The desired features to request from the
+     * physical device
+     * @param familyQueueIndices (Optional) List of queue indices to add for
+     * explicit allocation
+     * @param desiredExtensions (Optional) The desired extensions to load from
      * physicalDevice
      */
     Manager(uint32_t physicalDeviceIndex,
+            const vk::PhysicalDeviceFeatures& desiredFeatures,
             const std::vector<uint32_t>& familyQueueIndices = {},
             const std::vector<std::string>& desiredExtensions = {});
 
@@ -555,7 +574,8 @@ class Manager
     void createInstance();
     void createDevice(const std::vector<uint32_t>& familyQueueIndices = {},
                       uint32_t hysicalDeviceIndex = 0,
-                      const std::vector<std::string>& desiredExtensions = {});
+                      const std::vector<std::string>& desiredExtensions = {},
+                      const vk::PhysicalDeviceFeatures* pDesiredFeatures = nullptr);
 };
 
 } // End namespace kp

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -506,6 +506,14 @@ class Manager
     vk::PhysicalDeviceProperties getDeviceProperties() const;
 
     /**
+     * Information about the current device features.
+     *
+     * @return vk::PhysicalDeviceFeatures containing information about the
+     *device features
+     **/
+    vk::PhysicalDeviceFeatures getDeviceFeatures() const;
+
+    /**
      * List the devices available in the current vulkan instance.
      *
      * @return vector of physical devices containing their respective properties

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -79,7 +79,7 @@ TEST(TestAsyncOperations, TestManagerParallelExecution)
         EXPECT_EQ(inputsSyncB[i]->vector<float>(), resultSync);
     }
 
-    kp::Manager mgrAsync(0, { 0, 2 });
+    kp::Manager mgrAsync(0, std::vector<uint32_t>{ 0, 2 });
 
     std::vector<std::shared_ptr<kp::Memory>> inputsAsyncB;
 


### PR DESCRIPTION
I encountered the following error 
```
DEBUG:kp:[VALIDATION]: Validation - Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08740 ] | MessageID = 0x6e224e9 | vkCreateShaderModule():  SPIR-V Capability Float64 was declared, but one of the following requirements is required (VkPhysicalDeviceFeatures::shaderFloat64).
The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
```

So I added the ability to 1) report the available features and 2) request features when creating the device.
