### PR TITLE
Remove copy operations from classes in Kompute

### DIFF
--- a/src/include/kompute/Algorithm.hpp
+++ b/src/include/kompute/Algorithm.hpp
@@ -137,6 +137,16 @@ class Algorithm
     }
 
     /**
+     * @brief Make Algorithm uncopyable
+     *
+     */
+    Algorithm(const Algorithm&) = delete;
+    Algorithm(const Algorithm&&) = delete;
+    Algorithm& operator=(const Algorithm&) = delete;
+    Algorithm& operator=(const Algorithm&&) = delete;
+
+
+    /**
      * Destructor for Algorithm which is responsible for freeing and desroying
      * respective pipelines and owned parameter groups.
      */

--- a/src/include/kompute/Image.hpp
+++ b/src/include/kompute/Image.hpp
@@ -164,6 +164,16 @@ class Image : public Memory
     {
     }
 
+
+    /**
+     * @brief Make Image uncopyable
+     *
+     */
+    Image(const Image&) = delete;
+    Image(const Image&&) = delete;
+    Image& operator=(const Image&) = delete;
+    Image& operator=(const Image&&) = delete;
+
     /**
      * Destructor which is in charge of freeing vulkan resources unless they
      * have been provided externally.

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -50,6 +50,16 @@ class Manager
             std::shared_ptr<vk::PhysicalDevice> physicalDevice,
             std::shared_ptr<vk::Device> device);
 
+
+    /**
+     * @brief Make Manager uncopyable
+     *
+     */
+    Manager(const Manager&) = delete;
+    Manager(const Manager&&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager& operator=(const Manager&&) = delete;
+
     /**
      * Manager destructor which would ensure all owned resources are destroyed
      * unless explicitly stated that resources should not be destroyed or freed.

--- a/src/include/kompute/Memory.hpp
+++ b/src/include/kompute/Memory.hpp
@@ -63,6 +63,16 @@ class Memory
            uint32_t x,
            uint32_t y);
 
+
+    /**
+     * @brief Make Memory uncopyable
+     *
+     */
+    Memory(const Memory&) = delete;
+    Memory(const Memory&&) = delete;
+    Memory& operator=(const Memory&) = delete;
+    Memory& operator=(const Memory&&) = delete;
+
     /**
      * Destructor which is in charge of freeing vulkan resources unless they
      * have been provided externally.

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -29,6 +29,16 @@ class Sequence : public std::enable_shared_from_this<Sequence>
              std::shared_ptr<vk::Queue> computeQueue,
              uint32_t queueIndex,
              uint32_t totalTimestamps = 0) noexcept;
+
+    /**
+     * @brief Make Sequence uncopyable
+     *
+     */
+    Sequence(const Sequence&) = delete;
+    Sequence(const Sequence&&) = delete;
+    Sequence& operator=(const Sequence&) = delete;
+    Sequence& operator=(const Sequence&&) = delete;
+
     /**
      * Destructor for sequence which is responsible for cleaning all subsequent
      * owned operations.

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -58,6 +58,15 @@ class Tensor : public Memory
            const MemoryTypes& memoryType = MemoryTypes::eDevice);
 
     /**
+     * @brief Make Tensor uncopyable
+     *
+     */
+    Tensor(const Tensor&) = delete;
+    Tensor(const Tensor&&) = delete;
+    Tensor& operator=(const Tensor&) = delete;
+    Tensor& operator=(const Tensor&&) = delete;
+
+    /**
      * Destructor which is in charge of freeing vulkan resources unless they
      * have been provided externally.
      */
@@ -249,6 +258,16 @@ class TensorT : public Tensor
         KP_LOG_DEBUG("Kompute TensorT filling constructor with data size {}",
                      data.size());
     }
+
+    /**
+     * @brief Make TensorT uncopyable
+     *
+     */
+    TensorT(const TensorT&) = delete;
+    TensorT(const TensorT&&) = delete;
+    TensorT& operator=(const TensorT&) = delete;
+    TensorT& operator=(const TensorT&&) = delete;
+
 
     ~TensorT() { KP_LOG_DEBUG("Kompute TensorT destructor"); }
 

--- a/src/include/kompute/operations/OpAlgoDispatch.hpp
+++ b/src/include/kompute/operations/OpAlgoDispatch.hpp
@@ -44,6 +44,16 @@ class OpAlgoDispatch : public OpBase
     }
 
     /**
+     * @brief Make OpAlgoDispatch non-copyable
+     *
+     */
+    OpAlgoDispatch(const OpAlgoDispatch&) = delete;
+    OpAlgoDispatch(const OpAlgoDispatch&&) = delete;
+    OpAlgoDispatch& operator=(const OpAlgoDispatch&) = delete;
+    OpAlgoDispatch& operator=(const OpAlgoDispatch&&) = delete;
+
+
+    /**
      * Default destructor, which is in charge of destroying the algorithm
      * components but does not destroy the underlying tensors
      */

--- a/src/include/kompute/operations/OpBase.hpp
+++ b/src/include/kompute/operations/OpBase.hpp
@@ -19,6 +19,21 @@ namespace kp {
 class OpBase
 {
   public:
+      /**
+     * @brief Construct a new OpBase object
+     *
+     */
+    OpBase() = default;
+
+    /**
+     * @brief Make OpBase non-copyable
+     *
+     */
+    OpBase(const OpBase&) = delete;
+    OpBase(const OpBase&&) = delete;
+    OpBase& operator=(const OpBase&) = delete;
+    OpBase& operator=(const OpBase&&) = delete;
+
     /**
      * Default destructor for OpBase class. This OpBase destructor class should
      * always be called to destroy and free owned resources unless it is

--- a/src/include/kompute/operations/OpCopy.hpp
+++ b/src/include/kompute/operations/OpCopy.hpp
@@ -27,6 +27,15 @@ class OpCopy : public OpBase
     OpCopy(const std::vector<std::shared_ptr<Memory>>& memObjects);
 
     /**
+     * @brief Make OpCopy non-copyable
+     *
+     */
+    OpCopy(const OpCopy&) = delete;
+    OpCopy(const OpCopy&&) = delete;
+    OpCopy& operator=(const OpCopy&) = delete;
+    OpCopy& operator=(const OpCopy&&) = delete;
+
+    /**
      * Default destructor. This class does not manage memory so it won't be
      * expecting the parent to perform a release.
      */

--- a/src/include/kompute/operations/OpMemoryBarrier.hpp
+++ b/src/include/kompute/operations/OpMemoryBarrier.hpp
@@ -42,6 +42,15 @@ class OpMemoryBarrier : public OpBase
                     bool barrierOnPrimary = true) noexcept;
 
     /**
+     * @brief Make OpMemoryBarrier non-copyable
+     *
+     */
+    OpMemoryBarrier(const OpMemoryBarrier&) = delete;
+    OpMemoryBarrier(const OpMemoryBarrier&&) = delete;
+    OpMemoryBarrier& operator=(const OpMemoryBarrier&) = delete;
+    OpMemoryBarrier& operator=(const OpMemoryBarrier&&) = delete;
+
+    /**
      * Default destructor, which is in charge of destroying the reference to the
      * tensors and all the relevant access / stage masks created
      */

--- a/src/include/kompute/operations/OpMult.hpp
+++ b/src/include/kompute/operations/OpMult.hpp
@@ -49,6 +49,15 @@ class OpMult : public OpAlgoDispatch
     }
 
     /**
+     * @brief Make OpMult non-copyable
+     *
+     */
+    OpMult(const OpMult&) = delete;
+    OpMult(const OpMult&&) = delete;
+    OpMult& operator=(const OpMult&) = delete;
+    OpMult& operator=(const OpMult&&) = delete;
+
+    /**
      * Default destructor, which is in charge of destroying the algorithm
      * components but does not destroy the underlying tensors
      */

--- a/src/include/kompute/operations/OpSyncDevice.hpp
+++ b/src/include/kompute/operations/OpSyncDevice.hpp
@@ -29,6 +29,16 @@ class OpSyncDevice : public OpBase
     OpSyncDevice(const std::vector<std::shared_ptr<Memory>>& memObjects);
 
     /**
+     * @brief Make OpSyncDevice non-copyable
+     *
+     */
+    OpSyncDevice(const OpSyncDevice&) = delete;
+    OpSyncDevice(const OpSyncDevice&&) = delete;
+    OpSyncDevice& operator=(const OpSyncDevice&) = delete;
+    OpSyncDevice& operator=(const OpSyncDevice&&) = delete;
+
+
+    /**
      * Default destructor. This class does not manage memory so it won't be
      * expecting the parent to perform a release.
      */

--- a/src/include/kompute/operations/OpSyncLocal.hpp
+++ b/src/include/kompute/operations/OpSyncLocal.hpp
@@ -31,6 +31,15 @@ class OpSyncLocal : public OpBase
     OpSyncLocal(const std::vector<std::shared_ptr<Memory>>& memObjects);
 
     /**
+     * @brief Make OpSyncLocal non-copyable
+     *
+     */
+    OpSyncLocal(const OpSyncLocal&) = delete;
+    OpSyncLocal(const OpSyncLocal&&) = delete;
+    OpSyncLocal& operator=(const OpSyncLocal&) = delete;
+    OpSyncLocal& operator=(const OpSyncLocal&&) = delete;
+
+    /**
      * Default destructor. This class does not manage memory so it won't be
      * expecting the parent to perform a release.
      */


### PR DESCRIPTION
This is a little different from what described in Issue #20, but I made all the classes in Kompute non-copy. I did not create the NonCopiable class, however the impossibility to copy the classes comes from each class: this is because I do not want to create a class without a purpose other than making the language behave as we want, and because it would not make the copy/assignment operators un-overridable, so it would be possible to do some terrible things and enable the copy on them.