### PR TITLE
Fix syntax error (MSVC) in Manager.cpp

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -14,11 +14,11 @@ namespace kp {
 
 #ifndef KOMPUTE_DISABLE_VK_DEBUG_LAYERS
 #ifdef VK_VERSION_1_4
-VKAPI_PTR vk::Bool32 VKAPI_CALL
+VKAPI_ATTR vk::Bool32 VKAPI_CALL
 debugMessageCallback(vk::DebugReportFlagsEXT /*flags*/,
                      vk::DebugReportObjectTypeEXT /*objectType*/,
 #else
-static VKAPI_PTR VkBool32 VKAPI_CALL
+static VKAPI_ATTR VkBool32 VKAPI_CALL
 debugMessageCallback(VkDebugReportFlagsEXT /*flags*/,
                      VkDebugReportObjectTypeEXT /*objectType*/,
 #endif // VK_VERSION_1_4


### PR DESCRIPTION
Change VKAPI_PTR to VKAPI_ATTR

Tested only on:
MSVC version: `Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34808 for x86`
VulkanSDK version: 1.4.309.0
Latest kompute commit: 299b11fb4b8a7607c5d2c27e2735f26b06ae8e29