### PR TITLE
Fix compile error in android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,9 @@ endif()
 # Has to happen AFTER using the build-in Vulkan headers to prevent multiple targets with the name Vulkan::Headers
 if(KOMPUTE_OPT_ANDROID_BUILD)
     add_library(vulkanAndroid INTERFACE)
-    set(VULKAN_INCLUDE_DIR ${ANDROID_NDK}/sources/third_party/vulkan/src/include)
+    if(NOT DEFINED VULKAN_INCLUDE_DIR)
+        message(FATAL_ERROR "VULKAN_INCLUDE_DIR is not set. Please set it to the Vulkan SDK include directory.")
+    endif()
     target_sources(vulkanAndroid INTERFACE ${VULKAN_INCLUDE_DIR}/vulkan/vulkan.hpp)
     target_include_directories(vulkanAndroid INTERFACE ${VULKAN_INCLUDE_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ if(KOMPUTE_OPT_BUILD_PYTHON)
     target_link_libraries(kompute PRIVATE pybind11::headers ${PYTHON_LIBRARIES})
 endif()
 
-if(KOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER)
+if(NOT KOMPUTE_OPT_ANDROID_BUILD AND KOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER)
     target_link_libraries(kompute PUBLIC Vulkan-Headers)
 endif()
 


### PR DESCRIPTION
- Updated CMake to support the latest NDK which no longer includes Vulkan by default.
- Users now need to download [Vulkan SDK](https://vulkan.lunarg.com) and manually set VULKAN_INCLUDE_DIR, for example:
```
set(VULKAN_INCLUDE_DIR /path/to/VulkanSDK/1.3.296.0/macOS/include)
```
- Modified the condition for linking Vulkan-Headers: Now it only links when not building for Android.