### PR TITLE
update internal gtest to v1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ endif()
 if(KOMPUTE_OPT_BUILD_TESTS OR KOMPUTE_OPT_ENABLE_BENCHMARK)
     if(KOMPUTE_OPT_USE_BUILT_IN_GOOGLE_TEST)
         FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG release-1.11.0) # Source: https://github.com/google/googletest/releases
+            GIT_TAG v1.17.0) # Source: https://github.com/google/googletest/releases
 
         # Use a shared C runtime in case we build shared
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Problem is, when trying to build kompute with cmake >=4 and building the tests. (-DKOMPUTE_OPT_BUILD_TESTS=ON)
The CMake configuration will fail. Similar to https://github.com/KomputeProject/kompute/issues/422
```
CMake Error at build/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Instead of workarounds, like setting KOMPUTE_OPT_USE_BUILT_IN_GOOGLE_TEST=OFF or CMAKE_POLICY_VERSION_MINIMUM=3.5, it would probably best to just update the dependency. The PR adds the currently most recent version of gtest.