### PR TITLE
Make kp::Algorithm and kp::Sequence internals protected for subclassing

### DIFF
--- a/src/include/kompute/Algorithm.hpp
+++ b/src/include/kompute/Algorithm.hpp
@@ -291,7 +291,7 @@ class Algorithm
 
     void destroy();
 
-  private:
+  protected:
     // -------------- NEVER OWNED RESOURCES
     std::shared_ptr<vk::Device> mDevice;
     std::vector<std::shared_ptr<Memory>> mMemObjects;
@@ -312,6 +312,7 @@ class Algorithm
     std::shared_ptr<vk::Pipeline> mPipeline;
     bool mFreePipeline = false;
 
+  private:
     // -------------- ALWAYS OWNED RESOURCES
     std::vector<uint32_t> mSpirv;
     void* mSpecializationConstantsData = nullptr;

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -276,7 +276,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      */
     void destroy();
 
-  private:
+  protected:
     // -------------- NEVER OWNED RESOURCES
     std::shared_ptr<vk::PhysicalDevice> mPhysicalDevice = nullptr;
     std::shared_ptr<vk::Device> mDevice = nullptr;
@@ -298,6 +298,7 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     bool mRecording = false;
     bool mIsRunning = false;
 
+  private:
     // Create functions
     void createCommandPool();
     void createCommandBuffer();


### PR DESCRIPTION
At Veo Technologies, we are prototyping Kompute integration in a GStreamer pipeline so our custom GStreamer elements can leverage Vulkan in a simple and efficient way.

In order to make GStreamer and Kompute work together, we have to modify the Sequence and Algorithm classes a bit. For `kp::Algorithm` we need to change the input and output buffers on our Algorithm for each execution, as GStreamer gives us new buffers with every call. In order to do this, we changed the member variables from private to protected and created a new Algorithm subclass that inherits from `kp::Algorithm`.

For kp::Sequence we did the same thing, making the member variables protected. GStreamer implements a mutex lock you need to acquire before calling `vk::Queue::submit`, so our child class of `kp::Sequence` will acquire and release the lock before submitting to the queue.

This PR only changes `private` to `protected` for member variables. If you think others may benefit from our locking/unlocking, I can make a separate PR for that too.