### PR TITLE
Remove explicit checks against kp::Memory::type()

### DIFF
--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -134,7 +134,7 @@ Algorithm::createParameters()
     KP_LOG_DEBUG("Kompute Algorithm createParameters started");
 
     for (const std::shared_ptr<Memory>& mem : this->mMemObjects) {
-        if (mem->type() == Memory::Type::eImage) {
+        if (mem->getDescriptorType() == vk::DescriptorType::eStorageImage) {
             numImages++;
         } else {
             numTensors++;

--- a/src/OpAlgoDispatch.cpp
+++ b/src/OpAlgoDispatch.cpp
@@ -25,9 +25,8 @@ OpAlgoDispatch::record(const vk::CommandBuffer& commandBuffer)
 
         // For images the image layout needs to be set to eGeneral before using
         // it for imageLoad/imageStore in a shader.
-        if (mem->type() == Memory::Type::eImage) {
-            std::shared_ptr<Image> image = std::static_pointer_cast<Image>(mem);
-
+        std::shared_ptr<Image> image = std::dynamic_pointer_cast<Image>(mem);
+        if (image) {
             image->recordPrimaryImageBarrier(
               commandBuffer,
               vk::AccessFlagBits::eTransferWrite,


### PR DESCRIPTION
There is a few places in the codebase where assumptions are being made based on what a memory objects virtual `kp::Memory::type()` method returns. This makes it hard to create new subclasses because there is an implicit assumption that if `type()` returns `memory::Type::eImage` then it _is_ `kp::Image` and will behave like that.

This PR fixes two of those issues:

 - Update `Algorithm.cpp` to call `mem->getDescriptorType()` instead of `mem->type()` when allocating descriptor pools. With the current subclasses of `kp::Memory` this does not make a difference, but the explicit checks against memory type makes it hard to create new subclasses.
 - Update `OpAlgoDispatch.cpp` to actually check if the memory object is safe to cast to `kp::Image` instead of assuming that if `mem->type()` returns `memory::Type::eImage` this casting is safe.
 
With these changes it becomes safe to create new subclasses of `kp::Memory` that wraps images and uses image descriptors internally, without forcing those to subclass `kp::Image` (which isn't virtual and can't be subclassed anyway).

Those new subclasses will not really work with the strong-typed copy methods but they can implement their own copy methods for that if they feel like it.