### PR TITLE
Manager: forward optional VkPhysicalDeviceFeatures2 pNext chain to VkDeviceCreateInfo

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -51,7 +51,8 @@ Manager::Manager()
 
 Manager::Manager(uint32_t physicalDeviceIndex,
                  const std::vector<uint32_t>& familyQueueIndices,
-                 const std::vector<std::string>& desiredExtensions)
+                 const std::vector<std::string>& desiredExtensions,
+                 const void* desiredFeaturesChain)
 {
     this->mManageResources = true;
 
@@ -61,8 +62,10 @@ Manager::Manager(uint32_t physicalDeviceIndex,
 #endif
 
     this->createInstance();
-    this->createDevice(
-      familyQueueIndices, physicalDeviceIndex, desiredExtensions);
+    this->createDevice(familyQueueIndices,
+                       physicalDeviceIndex,
+                       desiredExtensions,
+                       desiredFeaturesChain);
 }
 
 Manager::Manager(std::shared_ptr<vk::Instance> instance,
@@ -328,7 +331,8 @@ Manager::clear()
 void
 Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
                       uint32_t physicalDeviceIndex,
-                      const std::vector<std::string>& desiredExtensions)
+                      const std::vector<std::string>& desiredExtensions,
+                      const void* desiredFeaturesChain)
 {
 
     KP_LOG_DEBUG("Kompute Manager creating Device");
@@ -469,6 +473,8 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
                                           {},
                                           validExtensions.size(),
                                           validExtensions.data());
+
+    deviceCreateInfo.pNext = desiredFeaturesChain;
 
     this->mDevice = std::make_shared<vk::Device>();
     physicalDevice.createDevice(

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -32,10 +32,14 @@ class Manager
      * explicit allocation
      * @param desiredExtensions The desired extensions to load from
      * physicalDevice
+     * @param desiredFeaturesChain (Optional) Caller-owned pNext chain
+     * forwarded to VkDeviceCreateInfo::pNext (e.g. a VkPhysicalDeviceFeatures2
+     * head enabling VK_EXT_shader_atomic_float).
      */
     Manager(uint32_t physicalDeviceIndex,
             const std::vector<uint32_t>& familyQueueIndices = {},
-            const std::vector<std::string>& desiredExtensions = {});
+            const std::vector<std::string>& desiredExtensions = {},
+            const void* desiredFeaturesChain = nullptr);
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
@@ -561,7 +565,8 @@ class Manager
     void createInstance();
     void createDevice(const std::vector<uint32_t>& familyQueueIndices = {},
                       uint32_t hysicalDeviceIndex = 0,
-                      const std::vector<std::string>& desiredExtensions = {});
+                      const std::vector<std::string>& desiredExtensions = {},
+                      const void* desiredFeaturesChain = nullptr);
 };
 
 } // End namespace kp


### PR DESCRIPTION
## Summary

Extends `kp::Manager`'s configured constructor (and the internal
`createDevice`) with an optional `const void* desiredFeaturesChain`
parameter.  When non-null it is forwarded to
`VkDeviceCreateInfo::pNext`, enabling callers to opt in to
extension-gated features such as
`VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32AtomicAdd`
or any other feature struct chain the application needs.

Without this, even if `VK_EXT_shader_atomic_float` is passed through
the existing `desiredExtensions` list, pipeline creation rejects
SPIR-V that uses `OpAtomicFAdd` on storage buffers because the
corresponding feature bit is never enabled.

The parameter defaults to `nullptr`, so all existing call sites
compile and behave exactly as before.  Ownership remains with the
caller — Manager only reads the pointer during `VkDeviceCreateInfo`
configuration and does not store it.

## Motivation

Kompute currently requires
subclassing `Manager` or reaching directly into the shared
`vk::Device` to reconfigure it, which defeats the point of the
Manager abstraction.  This small hook lets those workloads stay on
the stock Manager.

## Notes

Happy to add a small example under `examples/` showing the feature-chain
idiom if that's desired — didn't include one here to keep the diff
minimal and reviewable.  Also happy to narrow the API to a typed
`vk::PhysicalDeviceFeatures2*` if the maintainers prefer that over a
raw `const void*`; I chose the latter so callers can supply any
`pNext`-chainable struct without Manager having to know about it.