### PR TITLE
Sequence: reset mIsRunning on exception from submit/waitForFences

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -133,7 +133,12 @@ Sequence::evalAsync()
 
     this->mDevice->resetFences({ this->mFence });
 
-    this->mComputeQueue->submit(1, &submitInfo, this->mFence);
+    try {
+        this->mComputeQueue->submit(1, &submitInfo, this->mFence);
+    } catch (...) {
+        this->mIsRunning = false;
+        throw;
+    }
 
     return shared_from_this();
 }
@@ -155,8 +160,14 @@ Sequence::evalAwait(uint64_t waitFor)
         return shared_from_this();
     }
 
-    vk::Result result =
-      this->mDevice->waitForFences(1, &this->mFence, VK_TRUE, waitFor);
+    vk::Result result;
+    try {
+        result =
+          this->mDevice->waitForFences(1, &this->mFence, VK_TRUE, waitFor);
+    } catch (...) {
+        this->mIsRunning = false;
+        throw;
+    }
 
     this->mIsRunning = false;
 


### PR DESCRIPTION
Fixes #459.

`mIsRunning` is set true before `vkQueueSubmit` / `vkWaitForFences` but not reset on throw, deadlocking the next call. Catch-and-rethrow clears it; the exception propagates unchanged.

Supersedes #460.