### PR TITLE
Add semaphore-aware Sequence evalAsync overloads

### DIFF
--- a/docs/overview/advanced-examples.rst
+++ b/docs/overview/advanced-examples.rst
@@ -162,6 +162,9 @@ Async/Await Example
 
 A simple example of asynchronous submission can be found below.
 
+You can also use async submissions with Vulkan semaphores to synchronize
+Kompute-generated submits with user-managed queue submits.
+
 First we are able to create the manager as we normally would.
 
 .. code-block:: cpp
@@ -233,14 +236,24 @@ The parameter provided is the maximum amount of time to wait in nanoseconds. Whe
 
     auto sq = mgr.sequence();
 
-    // Run Async Kompute operation on the parameters provided
-    sq->evalAsync<kp::OpAlgoDispatch>(algo);
+    // Optional: pass submit-level synchronization primitives so this submit
+    // waits/signals alongside user-managed queue work
+    std::vector<vk::Semaphore> waitSemaphores = { externalWaitSemaphore };
+    std::vector<vk::PipelineStageFlags> waitDstStageMasks = {
+        vk::PipelineStageFlagBits::eComputeShader
+    };
+    std::vector<vk::Semaphore> signalSemaphores = { externalSignalSemaphore };
+    auto opAlgo = std::make_shared<kp::OpAlgoDispatch>(algo);
+    sq->evalAsync(opAlgo, waitSemaphores, waitDstStageMasks, signalSemaphores);
 
     // Here we can do other work
 
-    // When we're ready we can wait 
+    // When we're ready we can wait
     // The default wait time is UINT64_MAX
     sq->evalAwait();
+
+``evalAwait()`` must be called before invoking ``evalAsync()`` again on the
+same ``Sequence``.
 
 
 Finally, below you can see that we can also run syncrhonous commands without having to change anything.

--- a/docs/overview/advanced-examples.rst
+++ b/docs/overview/advanced-examples.rst
@@ -234,17 +234,17 @@ The parameter provided is the maximum amount of time to wait in nanoseconds. Whe
 .. code-block:: cpp
     :linenos:
 
-    auto sq = mgr.sequence();
-
-    // Optional: pass submit-level synchronization primitives so this submit
-    // waits/signals alongside user-managed queue work
+    // Optional: pass submit-level synchronization primitives once when
+    // creating the sequence so every submit waits/signals alongside
+    // user-managed queue work
     std::vector<vk::Semaphore> waitSemaphores = { externalWaitSemaphore };
     std::vector<vk::PipelineStageFlags> waitDstStageMasks = {
         vk::PipelineStageFlagBits::eComputeShader
     };
     std::vector<vk::Semaphore> signalSemaphores = { externalSignalSemaphore };
+    auto sq = mgr.sequence(0, 0, waitSemaphores, waitDstStageMasks, signalSemaphores);
     auto opAlgo = std::make_shared<kp::OpAlgoDispatch>(algo);
-    sq->evalAsync(opAlgo, waitSemaphores, waitDstStageMasks, signalSemaphores);
+    sq->evalAsync(opAlgo);
 
     // Here we can do other work
 

--- a/docs/overview/custom-operations.rst
+++ b/docs/overview/custom-operations.rst
@@ -33,7 +33,7 @@ Below you
    * - preEval()
      - When the Sequence is Evaluated this preEval is called across all operations before dispatching the batch of recorded commands to the GPU. This is useful for example if you need to copy data from local to host memory.
    * - postEval()
-     - After the sequence is Evaluated this postEval is called across all operations. When running asynchronously the postEval is called when you call `evalAwait()`, which is why it's important to always run evalAwait() to ensure the process doesn't go into inconsistent state.
+     - After the sequence is Evaluated this postEval is called across all operations. In asynchronous flows postEval is called when you run `evalAwait()`, and `evalAwait()` must be called before triggering `evalAsync()` again on the same sequence to avoid inconsistent state.
 
 
 Simple Operation Extending OpAlgoBase

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -336,7 +336,9 @@ PYBIND11_MODULE(kp, m)
            py::arg("desired_extensions") = std::vector<std::string>())
       .def("destroy", &kp::Manager::destroy, DOC(kp, Manager, destroy))
       .def("sequence",
-           &kp::Manager::sequence,
+           [](kp::Manager& self, uint32_t queueIndex, uint32_t totalTimestamps) {
+               return self.sequence(queueIndex, totalTimestamps, {}, {}, {});
+           },
            DOC(kp, Manager, sequence),
            py::arg("queue_index") = 0,
            py::arg("total_timestamps") = 0)

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -499,9 +499,19 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
 }
 
 std::shared_ptr<Sequence>
-Manager::sequence(uint32_t queueIndex, uint32_t totalTimestamps)
+Manager::sequence(uint32_t queueIndex,
+                  uint32_t totalTimestamps,
+                  const std::vector<vk::Semaphore>& waitSemaphores,
+                  const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+                  const std::vector<vk::Semaphore>& signalSemaphores)
 {
     KP_LOG_DEBUG("Kompute Manager sequence() with queueIndex: {}", queueIndex);
+
+    if (!waitDstStageMasks.empty() &&
+        waitSemaphores.size() != waitDstStageMasks.size()) {
+        throw std::runtime_error("Kompute Manager sequence() wait semaphore "
+                                 "count must match wait dst stage mask count");
+    }
 
     std::shared_ptr<std::mutex> submitMutex = nullptr;
 #ifdef KOMPUTE_OPT_THREAD_SAFE_COMPUTE_QUEUE
@@ -514,6 +524,9 @@ Manager::sequence(uint32_t queueIndex, uint32_t totalTimestamps)
         this->mComputeQueues[queueIndex],
         this->mComputeQueueFamilyIndices[queueIndex],
         totalTimestamps,
+        waitSemaphores,
+        waitDstStageMasks,
+        signalSemaphores,
         submitMutex) };
 
     if (this->mManageResources) {

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -9,6 +9,9 @@ Sequence::Sequence(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
                    std::shared_ptr<vk::Queue> computeQueue,
                    uint32_t queueIndex,
                    uint32_t totalTimestamps,
+                   const std::vector<vk::Semaphore>& waitSemaphores,
+                   const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+                   const std::vector<vk::Semaphore>& signalSemaphores,
                    std::shared_ptr<std::mutex> submitMutex) noexcept
 {
     KP_LOG_DEBUG("Kompute Sequence Constructor with existing device & queue");
@@ -19,6 +22,14 @@ Sequence::Sequence(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
     this->mQueueIndex = queueIndex;
     this->mFence = this->mDevice->createFence(vk::FenceCreateInfo());
     this->mSubmitMutex = submitMutex;
+    this->mWaitSemaphores = waitSemaphores;
+    this->mWaitDstStageMasks = waitDstStageMasks;
+    this->mSignalSemaphores = signalSemaphores;
+
+    if (this->mWaitDstStageMasks.empty() && !this->mWaitSemaphores.empty()) {
+        this->mWaitDstStageMasks.resize(this->mWaitSemaphores.size(),
+                                        vk::PipelineStageFlagBits::eAllCommands);
+    }
 
     this->createCommandPool();
     this->createCommandBuffer();
@@ -111,14 +122,6 @@ Sequence::eval(std::shared_ptr<OpBase> op)
 std::shared_ptr<Sequence>
 Sequence::evalAsync()
 {
-    return this->evalAsync({}, {}, {});
-}
-
-std::shared_ptr<Sequence>
-Sequence::evalAsync(const std::vector<vk::Semaphore>& waitSemaphores,
-                    const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
-                    const std::vector<vk::Semaphore>& signalSemaphores)
-{
     if (this->isRecording()) {
         this->end();
     }
@@ -135,34 +138,26 @@ Sequence::evalAsync(const std::vector<vk::Semaphore>& waitSemaphores,
         this->mOperations[i]->preEval(*this->mCommandBuffer);
     }
 
-    if (!waitDstStageMasks.empty() &&
-        waitSemaphores.size() != waitDstStageMasks.size()) {
+    if (!this->mWaitDstStageMasks.empty() &&
+        this->mWaitSemaphores.size() != this->mWaitDstStageMasks.size()) {
         throw std::runtime_error("Kompute Sequence evalAsync wait semaphore "
                                  "count must match wait dst stage mask count");
     }
 
-    std::vector<vk::PipelineStageFlags> resolvedWaitDstStageMasks =
-      waitDstStageMasks;
-    if (resolvedWaitDstStageMasks.empty() && !waitSemaphores.empty()) {
-        resolvedWaitDstStageMasks.resize(waitSemaphores.size(),
-                                         vk::PipelineStageFlagBits::eAllCommands);
-    }
-
     const vk::Semaphore* waitSemaphoresPtr =
-      waitSemaphores.empty() ? nullptr : waitSemaphores.data();
+      this->mWaitSemaphores.empty() ? nullptr : this->mWaitSemaphores.data();
     const vk::PipelineStageFlags* waitDstStageMasksPtr =
-      resolvedWaitDstStageMasks.empty() ? nullptr
-                                        : resolvedWaitDstStageMasks.data();
+      this->mWaitDstStageMasks.empty() ? nullptr : this->mWaitDstStageMasks.data();
     const vk::Semaphore* signalSemaphoresPtr =
-      signalSemaphores.empty() ? nullptr : signalSemaphores.data();
+      this->mSignalSemaphores.empty() ? nullptr : this->mSignalSemaphores.data();
 
     vk::SubmitInfo submitInfo(
-      static_cast<uint32_t>(waitSemaphores.size()),
+      static_cast<uint32_t>(this->mWaitSemaphores.size()),
       waitSemaphoresPtr,
       waitDstStageMasksPtr,
       1,
       this->mCommandBuffer.get(),
-      static_cast<uint32_t>(signalSemaphores.size()),
+      static_cast<uint32_t>(this->mSignalSemaphores.size()),
       signalSemaphoresPtr);
 
     KP_LOG_DEBUG(
@@ -189,19 +184,9 @@ Sequence::submitCommandBuffer(const vk::SubmitInfo& submitInfo)
 std::shared_ptr<Sequence>
 Sequence::evalAsync(std::shared_ptr<OpBase> op)
 {
-    return this->evalAsync(op, {}, {}, {});
-}
-
-std::shared_ptr<Sequence>
-Sequence::evalAsync(std::shared_ptr<OpBase> op,
-                    const std::vector<vk::Semaphore>& waitSemaphores,
-                    const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
-                    const std::vector<vk::Semaphore>& signalSemaphores)
-{
     this->clear();
     this->record(op);
-    return this->evalAsync(
-      waitSemaphores, waitDstStageMasks, signalSemaphores);
+    return this->evalAsync();
 }
 
 std::shared_ptr<Sequence>

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -111,6 +111,14 @@ Sequence::eval(std::shared_ptr<OpBase> op)
 std::shared_ptr<Sequence>
 Sequence::evalAsync()
 {
+    return this->evalAsync({}, {}, {});
+}
+
+std::shared_ptr<Sequence>
+Sequence::evalAsync(const std::vector<vk::Semaphore>& waitSemaphores,
+                    const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+                    const std::vector<vk::Semaphore>& signalSemaphores)
+{
     if (this->isRecording()) {
         this->end();
     }
@@ -127,8 +135,35 @@ Sequence::evalAsync()
         this->mOperations[i]->preEval(*this->mCommandBuffer);
     }
 
+    if (!waitDstStageMasks.empty() &&
+        waitSemaphores.size() != waitDstStageMasks.size()) {
+        throw std::runtime_error("Kompute Sequence evalAsync wait semaphore "
+                                 "count must match wait dst stage mask count");
+    }
+
+    std::vector<vk::PipelineStageFlags> resolvedWaitDstStageMasks =
+      waitDstStageMasks;
+    if (resolvedWaitDstStageMasks.empty() && !waitSemaphores.empty()) {
+        resolvedWaitDstStageMasks.resize(waitSemaphores.size(),
+                                         vk::PipelineStageFlagBits::eAllCommands);
+    }
+
+    const vk::Semaphore* waitSemaphoresPtr =
+      waitSemaphores.empty() ? nullptr : waitSemaphores.data();
+    const vk::PipelineStageFlags* waitDstStageMasksPtr =
+      resolvedWaitDstStageMasks.empty() ? nullptr
+                                        : resolvedWaitDstStageMasks.data();
+    const vk::Semaphore* signalSemaphoresPtr =
+      signalSemaphores.empty() ? nullptr : signalSemaphores.data();
+
     vk::SubmitInfo submitInfo(
-      0, nullptr, nullptr, 1, this->mCommandBuffer.get());
+      static_cast<uint32_t>(waitSemaphores.size()),
+      waitSemaphoresPtr,
+      waitDstStageMasksPtr,
+      1,
+      this->mCommandBuffer.get(),
+      static_cast<uint32_t>(signalSemaphores.size()),
+      signalSemaphoresPtr);
 
     KP_LOG_DEBUG(
       "Kompute sequence submitting command buffer into compute queue");
@@ -154,10 +189,19 @@ Sequence::submitCommandBuffer(const vk::SubmitInfo& submitInfo)
 std::shared_ptr<Sequence>
 Sequence::evalAsync(std::shared_ptr<OpBase> op)
 {
+    return this->evalAsync(op, {}, {}, {});
+}
+
+std::shared_ptr<Sequence>
+Sequence::evalAsync(std::shared_ptr<OpBase> op,
+                    const std::vector<vk::Semaphore>& waitSemaphores,
+                    const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+                    const std::vector<vk::Semaphore>& signalSemaphores)
+{
     this->clear();
     this->record(op);
-    this->evalAsync();
-    return shared_from_this();
+    return this->evalAsync(
+      waitSemaphores, waitDstStageMasks, signalSemaphores);
 }
 
 std::shared_ptr<Sequence>

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -77,10 +77,23 @@ class Manager
      * @param queueIndex The queue to use from the available queues
      * @param nrOfTimestamps The maximum number of timestamps to allocate.
      * If zero (default), disables latching of timestamps.
+     * @param waitSemaphores Semaphores to wait on before each submit from this
+     * sequence.
+     * @param waitDstStageMasks Pipeline stages to use for each wait semaphore.
+     * If empty and waitSemaphores is not empty, defaults to
+     * vk::PipelineStageFlagBits::eAllCommands for every wait semaphore.
+     * @param signalSemaphores Semaphores to signal after each submit from this
+     * sequence.
      * @returns Shared pointer with initialised sequence
      */
     std::shared_ptr<Sequence> sequence(uint32_t queueIndex = 0,
-                                       uint32_t totalTimestamps = 0);
+                                       uint32_t totalTimestamps = 0,
+                                       const std::vector<vk::Semaphore>&
+                                         waitSemaphores = {},
+                                       const std::vector<vk::PipelineStageFlags>&
+                                         waitDstStageMasks = {},
+                                       const std::vector<vk::Semaphore>&
+                                         signalSemaphores = {});
 
     /**
      * Create a managed tensor that will be destroyed by this manager

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -157,9 +157,10 @@ class Sequence : public std::enable_shared_from_this<Sequence>
 
     /**
      * Eval Async sends all the recorded and stored operations in the vector of
-     * operations into the gpu as a submit job without a barrier. EvalAwait()
-     * must ALWAYS be called after to ensure the sequence is terminated
-     * correctly.
+     * operations into the gpu as a submit job without a barrier.
+     *
+     * evalAwait() must be called before invoking evalAsync() again on this same
+     * Sequence to complete the previous async run and reset internal state.
      *
      * @return Boolean stating whether execution was successful.
      */
@@ -167,8 +168,11 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     /**
      * Eval Async sends all recorded operations as a submit job and allows
      * submit-level GPU synchronization by providing wait and signal semaphores.
-     * EvalAwait() must ALWAYS be called after to ensure the sequence is
-     * terminated correctly.
+     *
+     * This overload is useful for synchronizing Kompute submissions with
+     * user-managed queue submissions without forcing CPU-side synchronization.
+     * evalAwait() must be called before invoking evalAsync() again on this same
+     * Sequence to complete the previous async run and reset internal state.
      *
      * @param waitSemaphores Semaphores that must be signaled before this submit
      * starts executing.
@@ -185,9 +189,10 @@ class Sequence : public std::enable_shared_from_this<Sequence>
       const std::vector<vk::Semaphore>& signalSemaphores);
     /**
      * Clears currnet operations to record provided one in the vector of
-     * operations into the gpu as a submit job without a barrier. EvalAwait()
-     * must ALWAYS be called after to ensure the sequence is terminated
-     * correctly.
+     * operations into the gpu as a submit job without a barrier.
+     *
+     * evalAwait() must be called before invoking evalAsync() again on this same
+     * Sequence to complete the previous async run and reset internal state.
      *
      * @return Boolean stating whether execution was successful.
      */
@@ -195,8 +200,11 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     /**
      * Clears current operations, records the provided one and submits with
      * optional wait/signal semaphores for submit-level GPU synchronization.
-     * EvalAwait() must ALWAYS be called after to ensure the sequence is
-     * terminated correctly.
+     *
+     * This overload is useful for synchronizing Kompute submissions with
+     * user-managed queue submissions without forcing CPU-side synchronization.
+     * evalAwait() must be called before invoking evalAsync() again on this same
+     * Sequence to complete the previous async run and reset internal state.
      *
      * @param op Operation to record prior to submit.
      * @param waitSemaphores Semaphores that must be signaled before this submit

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -165,6 +165,25 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      */
     std::shared_ptr<Sequence> evalAsync();
     /**
+     * Eval Async sends all recorded operations as a submit job and allows
+     * submit-level GPU synchronization by providing wait and signal semaphores.
+     * EvalAwait() must ALWAYS be called after to ensure the sequence is
+     * terminated correctly.
+     *
+     * @param waitSemaphores Semaphores that must be signaled before this submit
+     * starts executing.
+     * @param waitDstStageMasks Pipeline stages at which to wait for each
+     * semaphore. If empty and waitSemaphores is not empty, defaults to
+     * vk::PipelineStageFlagBits::eAllCommands for each wait semaphore.
+     * @param signalSemaphores Semaphores that this submit will signal when it
+     * completes.
+     * @return shared_ptr<Sequence> of the Sequence class itself
+     */
+    std::shared_ptr<Sequence> evalAsync(
+      const std::vector<vk::Semaphore>& waitSemaphores,
+      const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+      const std::vector<vk::Semaphore>& signalSemaphores);
+    /**
      * Clears currnet operations to record provided one in the vector of
      * operations into the gpu as a submit job without a barrier. EvalAwait()
      * must ALWAYS be called after to ensure the sequence is terminated
@@ -173,6 +192,27 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync(std::shared_ptr<OpBase> op);
+    /**
+     * Clears current operations, records the provided one and submits with
+     * optional wait/signal semaphores for submit-level GPU synchronization.
+     * EvalAwait() must ALWAYS be called after to ensure the sequence is
+     * terminated correctly.
+     *
+     * @param op Operation to record prior to submit.
+     * @param waitSemaphores Semaphores that must be signaled before this submit
+     * starts executing.
+     * @param waitDstStageMasks Pipeline stages at which to wait for each
+     * semaphore. If empty and waitSemaphores is not empty, defaults to
+     * vk::PipelineStageFlagBits::eAllCommands for each wait semaphore.
+     * @param signalSemaphores Semaphores that this submit will signal when it
+     * completes.
+     * @return shared_ptr<Sequence> of the Sequence class itself
+     */
+    std::shared_ptr<Sequence> evalAsync(
+      std::shared_ptr<OpBase> op,
+      const std::vector<vk::Semaphore>& waitSemaphores,
+      const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
+      const std::vector<vk::Semaphore>& signalSemaphores);
     /**
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -31,6 +31,9 @@ class Sequence : public std::enable_shared_from_this<Sequence>
              std::shared_ptr<vk::Queue> computeQueue,
              uint32_t queueIndex,
              uint32_t totalTimestamps = 0,
+             const std::vector<vk::Semaphore>& waitSemaphores = {},
+             const std::vector<vk::PipelineStageFlags>& waitDstStageMasks = {},
+             const std::vector<vk::Semaphore>& signalSemaphores = {},
              std::shared_ptr<std::mutex> submitMutex = nullptr) noexcept;
 
     /**
@@ -158,6 +161,8 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     /**
      * Eval Async sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job without a barrier.
+     * Submit-level wait/signal semaphores are configured when creating the
+     * Sequence.
      *
      * evalAwait() must be called before invoking evalAsync() again on this same
      * Sequence to complete the previous async run and reset internal state.
@@ -166,30 +171,10 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      */
     std::shared_ptr<Sequence> evalAsync();
     /**
-     * Eval Async sends all recorded operations as a submit job and allows
-     * submit-level GPU synchronization by providing wait and signal semaphores.
-     *
-     * This overload is useful for synchronizing Kompute submissions with
-     * user-managed queue submissions without forcing CPU-side synchronization.
-     * evalAwait() must be called before invoking evalAsync() again on this same
-     * Sequence to complete the previous async run and reset internal state.
-     *
-     * @param waitSemaphores Semaphores that must be signaled before this submit
-     * starts executing.
-     * @param waitDstStageMasks Pipeline stages at which to wait for each
-     * semaphore. If empty and waitSemaphores is not empty, defaults to
-     * vk::PipelineStageFlagBits::eAllCommands for each wait semaphore.
-     * @param signalSemaphores Semaphores that this submit will signal when it
-     * completes.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    std::shared_ptr<Sequence> evalAsync(
-      const std::vector<vk::Semaphore>& waitSemaphores,
-      const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
-      const std::vector<vk::Semaphore>& signalSemaphores);
-    /**
      * Clears currnet operations to record provided one in the vector of
      * operations into the gpu as a submit job without a barrier.
+     * Submit-level wait/signal semaphores are configured when creating the
+     * Sequence.
      *
      * evalAwait() must be called before invoking evalAsync() again on this same
      * Sequence to complete the previous async run and reset internal state.
@@ -197,30 +182,6 @@ class Sequence : public std::enable_shared_from_this<Sequence>
      * @return Boolean stating whether execution was successful.
      */
     std::shared_ptr<Sequence> evalAsync(std::shared_ptr<OpBase> op);
-    /**
-     * Clears current operations, records the provided one and submits with
-     * optional wait/signal semaphores for submit-level GPU synchronization.
-     *
-     * This overload is useful for synchronizing Kompute submissions with
-     * user-managed queue submissions without forcing CPU-side synchronization.
-     * evalAwait() must be called before invoking evalAsync() again on this same
-     * Sequence to complete the previous async run and reset internal state.
-     *
-     * @param op Operation to record prior to submit.
-     * @param waitSemaphores Semaphores that must be signaled before this submit
-     * starts executing.
-     * @param waitDstStageMasks Pipeline stages at which to wait for each
-     * semaphore. If empty and waitSemaphores is not empty, defaults to
-     * vk::PipelineStageFlagBits::eAllCommands for each wait semaphore.
-     * @param signalSemaphores Semaphores that this submit will signal when it
-     * completes.
-     * @return shared_ptr<Sequence> of the Sequence class itself
-     */
-    std::shared_ptr<Sequence> evalAsync(
-      std::shared_ptr<OpBase> op,
-      const std::vector<vk::Semaphore>& waitSemaphores,
-      const std::vector<vk::PipelineStageFlags>& waitDstStageMasks,
-      const std::vector<vk::Semaphore>& signalSemaphores);
     /**
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
@@ -345,6 +306,9 @@ class Sequence : public std::enable_shared_from_this<Sequence>
     std::vector<std::shared_ptr<OpBase>> mOperations{};
     std::shared_ptr<vk::QueryPool> timestampQueryPool = nullptr;
     std::shared_ptr<std::mutex> mSubmitMutex = nullptr;
+    std::vector<vk::Semaphore> mWaitSemaphores{};
+    std::vector<vk::PipelineStageFlags> mWaitDstStageMasks{};
+    std::vector<vk::Semaphore> mSignalSemaphores{};
 
     // State
     bool mRecording = false;

--- a/test/TestSequence.cpp
+++ b/test/TestSequence.cpp
@@ -244,7 +244,7 @@ TEST(TestSequence, CorrectSequenceRunningError)
     EXPECT_EQ(tensorOut->vector(), std::vector<float>({ 2, 4, 6 }));
 }
 
-TEST(TestSequence, EvalAsyncSemaphoreOverloadSupportsEmptySyncLists)
+TEST(TestSequence, SequenceSubmitSyncSupportsEmptySyncLists)
 {
     kp::Manager mgr;
 
@@ -277,21 +277,15 @@ TEST(TestSequence, EvalAsyncSemaphoreOverloadSupportsEmptySyncLists)
     sq->record<kp::OpAlgoDispatch>(algo)->record<kp::OpSyncLocal>(
       { tensorA, tensorB, tensorOut });
 
-    EXPECT_NO_THROW(sq->evalAsync({}, {}, {}));
+    EXPECT_NO_THROW(sq->evalAsync());
     EXPECT_NO_THROW(sq->evalAwait());
 
     EXPECT_EQ(tensorOut->vector(), std::vector<float>({ 2, 4, 6 }));
 }
 
-TEST(TestSequence, EvalAsyncSemaphoreOverloadValidatesWaitMaskCount)
+TEST(TestSequence, SequenceSubmitSyncValidatesWaitMaskCount)
 {
     kp::Manager mgr;
-
-    std::shared_ptr<kp::Sequence> sq = mgr.sequence();
-
-    std::shared_ptr<kp::TensorT<float>> tensorA = mgr.tensor({ 1, 2, 3 });
-
-    sq->record<kp::OpSyncDevice>({ tensorA });
 
     std::vector<vk::Semaphore> waitSemaphores = { vk::Semaphore{} };
     std::vector<vk::PipelineStageFlags> waitDstStageMasks = {
@@ -300,6 +294,6 @@ TEST(TestSequence, EvalAsyncSemaphoreOverloadValidatesWaitMaskCount)
     };
     std::vector<vk::Semaphore> signalSemaphores = {};
 
-    EXPECT_ANY_THROW(
-      sq->evalAsync(waitSemaphores, waitDstStageMasks, signalSemaphores));
+    EXPECT_ANY_THROW(mgr.sequence(
+      0, 0, waitSemaphores, waitDstStageMasks, signalSemaphores));
 }

--- a/test/TestSequence.cpp
+++ b/test/TestSequence.cpp
@@ -243,3 +243,63 @@ TEST(TestSequence, CorrectSequenceRunningError)
 
     EXPECT_EQ(tensorOut->vector(), std::vector<float>({ 2, 4, 6 }));
 }
+
+TEST(TestSequence, EvalAsyncSemaphoreOverloadSupportsEmptySyncLists)
+{
+    kp::Manager mgr;
+
+    std::shared_ptr<kp::Sequence> sq = mgr.sequence();
+
+    std::shared_ptr<kp::TensorT<float>> tensorA = mgr.tensor({ 1, 2, 3 });
+    std::shared_ptr<kp::TensorT<float>> tensorB = mgr.tensor({ 2, 2, 2 });
+    std::shared_ptr<kp::TensorT<float>> tensorOut = mgr.tensor({ 0, 0, 0 });
+
+    sq->eval<kp::OpSyncDevice>({ tensorA, tensorB, tensorOut });
+
+    std::vector<uint32_t> spirv = compileSource(R"(
+        #version 450
+
+        layout (local_size_x = 1) in;
+
+        layout(set = 0, binding = 0) buffer bina { float tina[]; };
+        layout(set = 0, binding = 1) buffer binb { float tinb[]; };
+        layout(set = 0, binding = 2) buffer bout { float tout[]; };
+
+        void main() {
+            uint index = gl_GlobalInvocationID.x;
+            tout[index] = tina[index] * tinb[index];
+        }
+    )");
+
+    std::shared_ptr<kp::Algorithm> algo =
+      mgr.algorithm({ tensorA, tensorB, tensorOut }, spirv);
+
+    sq->record<kp::OpAlgoDispatch>(algo)->record<kp::OpSyncLocal>(
+      { tensorA, tensorB, tensorOut });
+
+    EXPECT_NO_THROW(sq->evalAsync({}, {}, {}));
+    EXPECT_NO_THROW(sq->evalAwait());
+
+    EXPECT_EQ(tensorOut->vector(), std::vector<float>({ 2, 4, 6 }));
+}
+
+TEST(TestSequence, EvalAsyncSemaphoreOverloadValidatesWaitMaskCount)
+{
+    kp::Manager mgr;
+
+    std::shared_ptr<kp::Sequence> sq = mgr.sequence();
+
+    std::shared_ptr<kp::TensorT<float>> tensorA = mgr.tensor({ 1, 2, 3 });
+
+    sq->record<kp::OpSyncDevice>({ tensorA });
+
+    std::vector<vk::Semaphore> waitSemaphores = { vk::Semaphore{} };
+    std::vector<vk::PipelineStageFlags> waitDstStageMasks = {
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eTransfer
+    };
+    std::vector<vk::Semaphore> signalSemaphores = {};
+
+    EXPECT_ANY_THROW(
+      sq->evalAsync(waitSemaphores, waitDstStageMasks, signalSemaphores));
+}


### PR DESCRIPTION
## Summary
- add `Sequence::evalAsync` overloads that accept wait/signal semaphores for submit-level GPU synchronization
- keep existing `evalAsync()` behavior by routing to the new overload with empty semaphore lists
- validate wait semaphore/stage-mask count pairing and add focused tests for the new overload path

## Test plan
- [x] `cmake -S . -B build -DKOMPUTE_OPT_BUILD_TESTS=ON`
- [x] `cmake --build build -j`
- [x] `./build/bin/kompute_tests --gtest_filter=TestSequence.EvalAsyncSemaphoreOverloadSupportsEmptySyncLists:TestSequence.EvalAsyncSemaphoreOverloadValidatesWaitMaskCount`