### PR TITLE
Scope `KOMPUTE_BUILD_PYTHON` to Python module and fix fmt include in Tensor.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,10 +243,6 @@ if(KOMPUTE_OPT_ANDROID_BUILD)
     add_compile_definitions(VK_USE_PLATFORM_ANDROID_KHR=1)
 endif()
 
-if(KOMPUTE_OPT_BUILD_PYTHON)
-    add_compile_definitions(KOMPUTE_BUILD_PYTHON=1)
-endif()
-
 if(KOMPUTE_OPT_DISABLE_VK_DEBUG_LAYERS)
     add_compile_definitions(KOMPUTE_DISABLE_VK_DEBUG_LAYERS=1)
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,3 +7,6 @@ include_directories(
 target_link_libraries(
         kp PRIVATE
         kompute::kompute)
+
+# Only the Python module needs KOMPUTE_BUILD_PYTHON
+target_compile_definitions(kp PRIVATE KOMPUTE_BUILD_PYTHON=1)

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/format.h>
 #include "kompute/Tensor.hpp"
 #include "kompute/Image.hpp"
 


### PR DESCRIPTION
This PR addresses issues discovered during [conda packaging](https://github.com/conda-forge/staged-recipes/pull/32329#issuecomment-4328403301). 

It scopes the `KOMPUTE_BUILD_PYTHON` compile definition to the Python module target only, fixes incorrectly mapped logging macros in `Logger.hpp` for Python builds, and adds missing fmt library includes in `Manager.cpp` and `Tensor.cpp`.

---

This pull request makes targeted improvements to how the Python build option is handled and updates an include in the `Tensor.cpp` source file. The main changes are:

**Build configuration improvements:**

* Moved the definition of `KOMPUTE_BUILD_PYTHON` so that it is now only set for the Python module build, rather than globally for all builds. This is done by removing the definition from the main `CMakeLists.txt` and adding it specifically to the Python module's `CMakeLists.txt` using `target_compile_definitions`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL246-L249) [[2]](diffhunk://#diff-005a07ca82fb46b215f58a3a8f4d6d6cc6ca088ade44e8f15cc2e6a51d1da6f4R10-R12)

**Source file update:**

* Added the `fmt/format.h` header include to `src/Tensor.cpp`, likely to support new or existing formatting functionality.