### PR TITLE
Fix compilation error when using Algorithm::setPushConstants(const std::vector<T> &)

### DIFF
--- a/src/include/kompute/Algorithm.hpp
+++ b/src/include/kompute/Algorithm.hpp
@@ -226,7 +226,7 @@ class Algorithm
      * @param size The number of data elements provided in the data
      * @param memorySize The memory size of each of the data elements in bytes.
      */
-    void setPushConstants(void* data, uint32_t size, uint32_t memorySize)
+    void setPushConstants(const void* data, uint32_t size, uint32_t memorySize)
     {
 
         uint32_t totalSize = memorySize * size;

--- a/test/TestPushConstant.cpp
+++ b/test/TestPushConstant.cpp
@@ -101,7 +101,6 @@ TEST(TestPushConstants, TestConstantsAlgoSetPushConstants)
     }
 }
 
-
 TEST(TestPushConstants, TestConstantsAlgoDispatchNoOverride)
 {
     {

--- a/test/TestPushConstant.cpp
+++ b/test/TestPushConstant.cpp
@@ -54,6 +54,54 @@ TEST(TestPushConstants, TestConstantsAlgoDispatchOverride)
     }
 }
 
+TEST(TestPushConstants, TestConstantsAlgoSetPushConstants)
+{
+    {
+        std::string shader(R"(
+          #version 450
+          layout(push_constant) uniform PushConstants {
+            float x;
+            float y;
+            float z;
+          } pcs;
+          layout (local_size_x = 1) in;
+          layout(set = 0, binding = 0) buffer a { float pa[]; };
+          void main() {
+              pa[0] += pcs.x;
+              pa[1] += pcs.y;
+              pa[2] += pcs.z;
+          })");
+
+        std::vector<uint32_t> spirv = compileSource(shader);
+
+        std::shared_ptr<kp::Sequence> sq = nullptr;
+
+        {
+            kp::Manager mgr;
+
+            std::shared_ptr<kp::TensorT<float>> tensor =
+              mgr.tensor({ 0, 0, 0 });
+
+            std::shared_ptr<kp::Algorithm> algo = mgr.algorithm(
+              { tensor }, spirv, kp::Workgroup({ 1 }), {}, { 0.0, 0.0, 0.0 });
+
+            sq = mgr.sequence()->eval<kp::OpSyncDevice>({ tensor });
+
+            // We need to run this in sequence to avoid race condition
+            // We can't use atomicAdd as swiftshader doesn't support it for
+            // float
+            algo->setPushConstants(std::vector<float>{ 0.1, 0.2, 0.3 });
+            sq->eval<kp::OpAlgoDispatch>(algo);
+            algo->setPushConstants(std::vector<float>{ 0.3, 0.2, 0.1 });
+            sq->eval<kp::OpAlgoDispatch>(algo);
+            sq->eval<kp::OpSyncLocal>({ tensor });
+
+            EXPECT_EQ(tensor->vector(), std::vector<float>({ 0.4, 0.4, 0.4 }));
+        }
+    }
+}
+
+
 TEST(TestPushConstants, TestConstantsAlgoDispatchNoOverride)
 {
     {


### PR DESCRIPTION
This function is templated and is never instantiated in `kompute` project so the compilation error was not detected. 

When calling `Algorithm::setPushConstants(const std::vector<T> &)`, this function then calls `Algorithm::setPushConstants(void* data, uint32_t size, uint32_t memorySize)` which accepts `non-const` pointer. 

This PR adds a test that instantiates this function and validates the results and also fixes the incorrect function signature.

```
[ 67%] Building CXX object test/CMakeFiles/kompute_tests.dir/TestPushConstant.cpp.o
In file included from <redacted>/kompute/src/include/kompute/Kompute.hpp:3,
                 from <redacted>/kompute/test/TestPushConstant.cpp:5:
<redacted>/kompute/src/include/kompute/Algorithm.hpp: In instantiation of ‘void kp::Algorithm::setPushConstants(const std::vector<T>&) [with T = float]’:
<redacted>/kompute/test/TestPushConstant.cpp:93:35:   required from here
<redacted>/kompute/src/include/kompute/Algorithm.hpp:217:31: error: no matching function for call to ‘kp::Algorithm::setPushConstants(const float*, uint32_t&, uint32_t&)’
  217 |         this->setPushConstants(pushConstants.data(), size, memorySize);
      |         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>/kompute/src/include/kompute/Algorithm.hpp:229:10: note: candidate: ‘void kp::Algorithm::setPushConstants(void*, uint32_t, uint32_t)’ (near match)
  229 |     void setPushConstants(void* data, uint32_t size, uint32_t memorySize)
      |          ^~~~~~~~~~~~~~~~
<redacted>/kompute/src/include/kompute/Algorithm.hpp:229:10: note:   conversion of argument 1 would be ill-formed:
<redacted>/kompute/src/include/kompute/Algorithm.hpp:217:50: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  217 |         this->setPushConstants(pushConstants.data(), size, memorySize);
      |                                ~~~~~~~~~~~~~~~~~~^~
      |                                                  |
      |                                                  const void*
<redacted>/kompute/src/include/kompute/Algorithm.hpp:212:10: note: candidate: ‘template<class T> void kp::Algorithm::setPushConstants(const std::vector<T>&)’
  212 |     void setPushConstants(const std::vector<T>& pushConstants)
      |          ^~~~~~~~~~~~~~~~
<redacted>/kompute/src/include/kompute/Algorithm.hpp:212:10: note:   template argument deduction/substitution failed:
<redacted>/kompute/src/include/kompute/Algorithm.hpp:217:31: note:   mismatched types ‘const std::vector<T>’ and ‘const float*’
  217 |         this->setPushConstants(pushConstants.data(), size, memorySize);
      |         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [test/CMakeFiles/kompute_tests.dir/build.make:191: test/CMakeFiles/kompute_tests.dir/TestPushConstant.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:674: test/CMakeFiles/kompute_tests.dir/all] Error 2
gmake: *** [Makefile:166: all] Error 2
```