### PR TITLE
Update documentation to match recent class renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ def kompute(shader):
 
     # 4. Run operation synchronously using sequence
     (mgr.sequence()
-        .record(kp.OpTensorSyncDevice(params))
+        .record(kp.OpSyncDevice(params))
         .record(kp.OpAlgoDispatch(algo)) # Binds default push consts provided
         .eval() # evaluates the two recorded ops
         .record(kp.OpAlgoDispatch(algo, push_consts_b)) # Overrides push consts
@@ -212,7 +212,7 @@ def kompute(shader):
 
     # 5. Sync results from the GPU asynchronously
     sq = mgr.sequence()
-    sq.eval_async(kp.OpTensorSyncLocal(params))
+    sq.eval_async(kp.OpSyncLocal(params))
 
     # ... Do other work asynchronously whilst GPU finishes
 

--- a/docs/overview/custom-operations.rst
+++ b/docs/overview/custom-operations.rst
@@ -11,7 +11,7 @@ These nuances are important for more advanced users of Kompute, as this will pro
 Flow of Function Calls
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The top level operation which all operations inherit from is the :class:`kp::OpBase` class. Some of the "Core Native Operations" like :class:`kp::OpTensorCopy`, :class:`kp::OpTensorCreate`, etc all inherit from the base operation class.
+The top level operation which all operations inherit from is the :class:`kp::OpBase` class. Some of the "Core Native Operations" like :class:`kp::OpCopy`, :class:`kp::OpTensorCreate`, etc all inherit from the base operation class.
 
 The `kp::OpAlgoBase` is another base operation that is specifically built to enable users to create their own operations that contain custom shader logic (i.e. requiring Compute Pipelines, DescriptorSets, etc). The next section contains an example which shows how to extend the OpAlgoBase class.
 

--- a/docs/overview/python-examples.rst
+++ b/docs/overview/python-examples.rst
@@ -14,7 +14,7 @@ Then you can interact with it from your interpreter. Below is the same sample as
 .. code-block:: python
    :linenos:
 
-   from kp import Manager, Tensor, OpTensorSyncDevice, OpTensorSyncLocal, OpAlgoDispatch
+   from kp import Manager, Tensor, OpSyncDevice, OpSyncLocal, OpAlgoDispatch
    from pyshader import python2shader, ivec3, f32, Array
 
    mgr = Manager()
@@ -26,7 +26,7 @@ Then you can interact with it from your interpreter. Below is the same sample as
 
    sq = mgr.sequence()
 
-   sq.eval(OpTensorSyncDevice([tensor_in_a, tensor_in_b, tensor_out]))
+   sq.eval(OpSyncDevice([tensor_in_a, tensor_in_b, tensor_out]))
 
    # Define the function via PyShader or directly as glsl string or spirv bytes
    @python2shader
@@ -41,7 +41,7 @@ Then you can interact with it from your interpreter. Below is the same sample as
 
    # Run shader operation synchronously
    sq.eval(OpAlgoDispatch(algo))
-   sq.eval(OpTensorSyncLocal([tensor_out]))
+   sq.eval(OpSyncLocal([tensor_out]))
 
    assert tensor_out.data().tolist() == [2.0, 4.0, 6.0]
 
@@ -69,7 +69,7 @@ Similarly you can find the same extended example as above:
     assert(tensor_out.data_type() == kp.DataTypes.float)
 
     seq = mgr.sequence()
-    seq.eval(kp.OpTensorSyncDevice([tensor_in_a, tensor_in_b, tensor_out]))
+    seq.eval(kp.OpSyncDevice([tensor_in_a, tensor_in_b, tensor_out]))
 
     # Define the function via PyShader or directly as glsl string or spirv bytes
     @python2shader
@@ -86,9 +86,9 @@ Similarly you can find the same extended example as above:
     seq.eval_async(kp.OpAlgoDispatch(algo))
     seq.eval_await()
 
-    seq.record(kp.OpTensorSyncLocal([tensor_in_a]))
-    seq.record(kp.OpTensorSyncLocal([tensor_in_b]))
-    seq.record(kp.OpTensorSyncLocal([tensor_out]))
+    seq.record(kp.OpSyncLocal([tensor_in_a]))
+    seq.record(kp.OpSyncLocal([tensor_in_b]))
+    seq.record(kp.OpSyncLocal([tensor_out]))
 
     seq.eval()
 
@@ -114,7 +114,7 @@ Handling multiple capabilites of processing can be done by compute shaders being
     t2 = mgr.tensor([1,2,3])
     t3 = mgr.tensor([1,2,3])
 
-    mgr.sequence().eval(kp.OpTensorSyncLocal([t1, t3]))
+    mgr.sequence().eval(kp.OpSyncLocal([t1, t3]))
 
     # Create multiple separate sequences
     sq_mult = mgr.sequence()
@@ -125,7 +125,7 @@ Handling multiple capabilites of processing can be done by compute shaders being
 
     sq_sum.record(kp.OpAlgoDispatch(mgr.algorithm([t3, t2, t1], sum_shader))
 
-    sq_sync.record(kp.OpTensorSyncLocal([t1, t3]))
+    sq_sync.record(kp.OpSyncLocal([t1, t3]))
 
     # Run multiple iterations
     for i in range(10):
@@ -211,14 +211,14 @@ Similar to the logistic regression implementation in the C++ examples section, b
     params = [tensor_x_i, tensor_x_j, tensor_y, tensor_w_in, tensor_w_out_i,
         tensor_w_out_j, tensor_b_in, tensor_b_out, tensor_l_out, tensor_m]
 
-    sq.sequence().eval(kp.OpTensorSyncDevice(params))
+    sq.sequence().eval(kp.OpSyncDevice(params))
 
     # Record commands for efficient evaluation
     sq = mgr.sequence()
 
-    sq.record(kp.OpTensorSyncDevice([tensor_w_in, tensor_b_in]))
+    sq.record(kp.OpSyncDevice([tensor_w_in, tensor_b_in]))
     sq.record(kp.OpAlgoDispatch(mgr.algorithm(params, compute_shader.to_spirv())))
-    sq.record(kp.OpTensorSyncLocal([tensor_w_out_i, tensor_w_out_j, tensor_b_out, tensor_l_out]))
+    sq.record(kp.OpSyncLocal([tensor_w_out_i, tensor_w_out_j, tensor_b_out, tensor_l_out]))
 
     ITERATIONS = 100
     learning_rate = 0.1

--- a/docs/overview/reference.rst
+++ b/docs/overview/reference.rst
@@ -87,28 +87,28 @@ The :class:`kp::OpMult` operation is a sample implementation of the :class:`kp::
    :members:
 
 
-OpTensorCopy
+OpCopy
 -------
 
-The :class:`kp::OpTensorCopy` is a tensor only operation that copies the GPU memory buffer data from one :class:`kp::Tensor` to one or more subsequent tensors.
+The :class:`kp::OpCopy` is a tensor only operation that copies the GPU memory buffer data from one :class:`kp::Tensor` to one or more subsequent tensors.
 
-.. doxygenclass:: kp::OpTensorCopy
+.. doxygenclass:: kp::OpCopy
    :members:
 
-OpTensorSyncLocal
+OpSyncLocal
 -------
 
-The :class:`kp::OpTensorSyncLocal` is a tensor only operation that maps the data from the GPU device memory into the local host vector.
+The :class:`kp::OpSyncLocal` is a tensor only operation that maps the data from the GPU device memory into the local host vector.
 
-.. doxygenclass:: kp::OpTensorSyncLocal
+.. doxygenclass:: kp::OpSyncLocal
    :members:
 
-OpTensorSyncDevice
+OpSyncDevice
 -------
 
-The :class:`kp::OpTensorSyncDevice` is a tensor only operation that maps the data from the local host vector into the GPU device memory.
+The :class:`kp::OpSyncDevice` is a tensor only operation that maps the data from the local host vector into the GPU device memory.
 
-.. doxygenclass:: kp::OpTensorSyncDevice
+.. doxygenclass:: kp::OpSyncDevice
    :members:
 
 OpMemoryBarrier
@@ -116,7 +116,7 @@ OpMemoryBarrier
 
 The :class:`kp::OpMemoryBarrier` is a tensor only operation which adds memory barriers to the tensors provided with the access and stage masks provided.
 
-.. doxygenclass:: kp::OpTensorSyncDevice
+.. doxygenclass:: kp::OpSyncDevice
    :members:
 
 

--- a/examples/godot_examples/custom_module/kompute_summator/KomputeSummatorNode.cpp
+++ b/examples/godot_examples/custom_module/kompute_summator/KomputeSummatorNode.cpp
@@ -83,13 +83,13 @@ KomputeSummatorNode::_init()
 
         // First we ensure secondary tensor loads to GPU
         // No need to sync the primary tensor as it should not be changed
-        sq->record<kp::OpTensorSyncDevice>({ this->mSecondaryTensor });
+        sq->record<kp::OpSyncDevice>({ this->mSecondaryTensor });
 
         // Then we run the operation with both tensors
         sq->record<kp::OpAlgoDispatch>(algo);
 
         // We map the result back to local
-        sq->record<kp::OpTensorSyncLocal>({ this->mPrimaryTensor });
+        sq->record<kp::OpSyncLocal>({ this->mPrimaryTensor });
 
     } else {
         throw std::runtime_error("Sequence pointer no longer available");

--- a/examples/godot_examples/gdnative_shared/src/KomputeSummator.cpp
+++ b/examples/godot_examples/gdnative_shared/src/KomputeSummator.cpp
@@ -80,7 +80,7 @@ KomputeSummator::_init()
 
         // First we ensure secondary tensor loads to GPU
         // No need to sync the primary tensor as it should not be changed
-        this->mSequence->record<kp::OpTensorSyncDevice>(
+        this->mSequence->record<kp::OpSyncDevice>(
           { this->mSecondaryTensor });
 
         // Then we run the operation with both tensors
@@ -89,7 +89,7 @@ KomputeSummator::_init()
           compileSource(shader));
 
         // We map the result back to local
-        this->mSequence->record<kp::OpTensorSyncLocal>(
+        this->mSequence->record<kp::OpSyncLocal>(
           { this->mPrimaryTensor });
 
         this->mSequence->end();

--- a/examples/godot_logistic_regression/custom_module/kompute_model_ml/KomputeModelMLNode.cpp
+++ b/examples/godot_logistic_regression/custom_module/kompute_model_ml/KomputeModelMLNode.cpp
@@ -64,13 +64,13 @@ KomputeModelMLNode::train(Array yArr, Array xIArr, Array xJArr)
 
             std::shared_ptr<kp::Algorithm> algo = mgr.algorithm(params, spirv);
 
-            mgr.sequence()->eval<kp::OpTensorSyncDevice>(params);
+            mgr.sequence()->eval<kp::OpSyncDevice>(params);
 
             std::shared_ptr<kp::Sequence> sq =
               mgr.sequence()
-                ->record<kp::OpTensorSyncDevice>({ wIn, bIn })
+                ->record<kp::OpSyncDevice>({ wIn, bIn })
                 ->record<kp::OpAlgoDispatch>(algo)
-                ->record<kp::OpTensorSyncLocal>({ wOutI, wOutJ, bOut, lOut });
+                ->record<kp::OpSyncLocal>({ wOutI, wOutJ, bOut, lOut });
 
             // Iterate across all expected iterations
             for (size_t i = 0; i < ITERATIONS; i++) {

--- a/examples/godot_logistic_regression/gdnative_shared/src/KomputeModelML.cpp
+++ b/examples/godot_logistic_regression/gdnative_shared/src/KomputeModelML.cpp
@@ -68,13 +68,13 @@ KomputeModelML::train(Array yArr, Array xIArr, Array xJArr)
 
             std::shared_ptr<kp::Algorithm> algo = mgr.algorithm(params, spirv);
 
-            mgr.sequence()->eval<kp::OpTensorSyncDevice>(params);
+            mgr.sequence()->eval<kp::OpSyncDevice>(params);
 
             std::shared_ptr<kp::Sequence> sq =
               mgr.sequence()
-                ->record<kp::OpTensorSyncDevice>({ wIn, bIn })
+                ->record<kp::OpSyncDevice>({ wIn, bIn })
                 ->record<kp::OpAlgoDispatch>(algo)
-                ->record<kp::OpTensorSyncLocal>({ wOutI, wOutJ, bOut, lOut });
+                ->record<kp::OpSyncLocal>({ wOutI, wOutJ, bOut, lOut });
 
             // Iterate across all expected iterations
             for (size_t i = 0; i < ITERATIONS; i++) {

--- a/test/TestOpCopyTensor.cpp
+++ b/test/TestOpCopyTensor.cpp
@@ -359,7 +359,7 @@ TEST(TestOpCopyTensor, CopyTensorThroughStorageViaAlgorithmsUninitialisedOutput)
     EXPECT_EQ(tensorIn->vector(), tensorOut->vector());
 }
 
-TEST(TestOpTensorCopy, CopyDeviceAndHostToDeviceAndHostTensor)
+TEST(TestOpCopy, CopyDeviceAndHostToDeviceAndHostTensor)
 {
     kp::Manager mgr;
 

--- a/test/TestOpCopyTensorToImage.cpp
+++ b/test/TestOpCopyTensorToImage.cpp
@@ -214,7 +214,7 @@ TEST(TestOpCopyTensorToImage, CopyDeviceToDeviceImageUninitialised)
     EXPECT_EQ(tensorA->vector(), imageB->vector());
 }
 
-TEST(TestOpTensorCopyToImage, CopyDeviceAndHostToDeviceAndHostTensor)
+TEST(TestOpCopyToImage, CopyDeviceAndHostToDeviceAndHostTensor)
 {
     kp::Manager mgr;
 


### PR DESCRIPTION
This PR updates documentation and examples after 
https://github.com/KomputeProject/kompute/commit/e79fa685c0161ad807a020b750e859bead60d877 renamed `OpTensorCopy`, `OpTensorSyncLocal` and `OpTensorSyncDevice` to `OpCopy`, `OpSyncLocal`, `OpSyncDevice`.