### PR TITLE
Fixed compilation issue with fmt > 11

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -7,6 +7,7 @@
 #include <spdlog/fmt/fmt.h>
 #else
 #include <fmt/core.h>
+#include <fmt/format.h>
 #endif
 
 namespace kp {

--- a/src/include/kompute/logger/Logger.hpp
+++ b/src/include/kompute/logger/Logger.hpp
@@ -21,16 +21,19 @@
 #if VK_USE_PLATFORM_ANDROID_KHR
 #include <android/log.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #else
 #if KOMPUTE_BUILD_PYTHON
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 // from python/src/main.cpp
 extern py::object kp_trace, kp_debug, kp_info, kp_warning, kp_error;
 #else
 #include <fmt/core.h>
+#include <fmt/format.h>
 #endif // KOMPUTE_BUILD_PYTHON
 #endif // VK_USE_PLATFORM_ANDROID_KHR
 #else


### PR DESCRIPTION
fmt has deprecated using fmt::format by including fmt/core.h (see [this file](https://github.com/fmtlib/fmt/blob/main/include/fmt/core.h), this results in Kompute not compiling as a vcpkg project when its flags are set to `KOMPUTE_OPT_USE_BUILT_IN_FMT=OFF` as vcpkg defaults to [version 12.2](https://vcpkg.io/en/package/fmt).

This PR fixes this issue by including fmt/format.h in the 2 files where fmt::format is used directly.

Confirmed to compile on linux both as a vcpkg project and via the standalone dependency resolution which still uses fmt 11.